### PR TITLE
Fix permissions issues on Windows servers.

### DIFF
--- a/src/Platform/Windows/WindowsPlatform.php
+++ b/src/Platform/Windows/WindowsPlatform.php
@@ -54,7 +54,7 @@ class WindowsPlatform implements PlatformInterface
         if (is_dir($path) && $permission->isRecursive()) {
             $command = 'icacls '.ProcessUtils::escapeArgument($path).' /remove:g '.ProcessUtils::escapeArgument($user).' /grant '.ProcessUtils::escapeArgument($user.':(OI)(CI)'.$modes).' /t /Q';
         } else {
-            $command = 'icacls '.ProcessUtils::escapeArgument($path).' /remove:g '.ProcessUtils::escapeArgument($user).' /grant '.ProcessUtils::escapeArgument($user.':(OI)(CI)'.$modes).' /Q';
+            $command = 'icacls '.ProcessUtils::escapeArgument($path).' /remove:g '.ProcessUtils::escapeArgument($user).' /grant '.ProcessUtils::escapeArgument($user.':'.$modes).' /Q';
         }
 
         $this->processRunner->run($command);

--- a/tests/Platform/Windows/WindowsPlatformTest.php
+++ b/tests/Platform/Windows/WindowsPlatformTest.php
@@ -34,13 +34,24 @@ class WindowsPlatformTest extends \PHPUnit_Framework_TestCase
         $permission = Permission::create('', array('r', 'w', 'x'));
 
         $this->processRunner->shouldReceive('run')
-            ->with("icacls 'vfs://root/jadu/JaduConstants.php' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:(OI)(CI)RXWM' /Q")
+            ->with("icacls 'vfs://root/jadu/JaduConstants.php' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:RXWM' /Q")
             ->once();
 
         $this->platform->setPermission(vfsStream::url('root/jadu/JaduConstants.php'), $permission);
     }
 
     public function testSetPermissionWithDirectory()
+    {
+        $permission = Permission::create('', array('r', 'w', 'x'));
+
+        $this->processRunner->shouldReceive('run')
+            ->with("icacls 'vfs://root/jadu/custom' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:RXWM' /Q")
+            ->once();
+
+        $this->platform->setPermission(vfsStream::url('root/jadu/custom'), $permission);
+    }
+
+    public function testSetPermissionWithDirectoryAndRecursive()
     {
         $permission = Permission::create('', array('r', 'w', 'x', 'R'));
 
@@ -56,7 +67,7 @@ class WindowsPlatformTest extends \PHPUnit_Framework_TestCase
         $permission = Permission::create('', array('r', 'w', 'x', 'R'));
 
         $this->processRunner->shouldReceive('run')
-            ->with("icacls 'vfs://root/jadu/JaduConstants.php' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:(OI)(CI)RXWM' /Q")
+            ->with("icacls 'vfs://root/jadu/JaduConstants.php' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:RXWM' /Q")
             ->once();
 
         $this->platform->setPermission(vfsStream::url('root/jadu/JaduConstants.php'), $permission);
@@ -67,7 +78,7 @@ class WindowsPlatformTest extends \PHPUnit_Framework_TestCase
         $permission = Permission::create('', array('x'));
 
         $this->processRunner->shouldReceive('run')
-            ->with("icacls 'vfs://root/jadu/JaduConstants.php' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:(OI)(CI)RX' /Q")
+            ->with("icacls 'vfs://root/jadu/JaduConstants.php' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:RX' /Q")
             ->once();
 
         $this->platform->setPermission(vfsStream::url('root/jadu/JaduConstants.php'), $permission);


### PR DESCRIPTION
The `(OI)(CI)` modes should only be used for directories and if we want permissions to be recursive.
