### PR TITLE
Add --skip-combine option to skip combining of packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vX.Y.Z
 
 * Improved error message when not specifying a package name in migration commands ([#10](https://github.com/jadu/meteor/pull/10))
+* Added `--skip-combine` option to skip package combining ([#11](https://github.com/jadu/meteor/pull/11))
 
 ## v2.0.2
 

--- a/src/Package/Cli/Command/PackageCommand.php
+++ b/src/Package/Cli/Command/PackageCommand.php
@@ -37,6 +37,7 @@ class PackageCommand extends AbstractCommand
         $this->addOption('output-dir', 'o', InputOption::VALUE_REQUIRED, 'The directory to put the ZIP archive in.', 'output');
         $this->addOption('filename', 'f', InputOption::VALUE_REQUIRED, 'The name given to the package ZIP archive.');
         $this->addOption('combine', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'One or more packages to combine with this package.');
+        $this->addOption('skip-combine', null, InputOption::VALUE_NONE, 'Do not combine packages automatically based on the config.');
         $this->addOption('phar', null, InputOption::VALUE_REQUIRED, 'The path to a Phar archive to bundle with the package.');
 
         parent::configure();
@@ -54,6 +55,7 @@ class PackageCommand extends AbstractCommand
             $this->io->getOption('filename'),
             $this->getConfiguration(),
             $this->io->getOption('combine'),
+            $this->io->getOption('skip-combine'),
             $this->io->getOption('phar')
         );
 

--- a/src/Package/PackageCreator.php
+++ b/src/Package/PackageCreator.php
@@ -89,8 +89,9 @@ class PackageCreator
      * @param string $workingDir
      * @param string $outputDir
      * @param string $fileName
-     * @param array  $config
-     * @param array  $combinePackages
+     * @param array $config
+     * @param array $combinePackages
+     * @param bool $skipCombine
      * @param string $pharPath
      *
      * @return bool
@@ -98,7 +99,7 @@ class PackageCreator
      * @throws Exception
      * @throws \Meteor\Configuration\RuntimeException
      */
-    public function create($workingDir, $outputDir, $fileName, array $config, array $combinePackages, $pharPath = null)
+    public function create($workingDir, $outputDir, $fileName, array $config, array $combinePackages, $skipCombine = false, $pharPath = null)
     {
         $this->io->title(sprintf('Creating package for <info>%s</>', $config['name']));
 
@@ -118,8 +119,10 @@ class PackageCreator
             $composerRequirements = $this->composerDependencyChecker->getRequirements($workingDir);
             $hasComposerRequirements = !empty($composerRequirements);
 
-            // Combine packages passed and automatically resolve required packages using the provider
-            $config = $this->combinedPackageResolver->resolve($combinePackages, $outputDir, $tempDir, $config, $hasComposerRequirements);
+            if (!$skipCombine) {
+                // Combine packages passed and automatically resolve required packages using the provider
+                $config = $this->combinedPackageResolver->resolve($combinePackages, $outputDir, $tempDir, $config, $hasComposerRequirements);
+            }
 
             if ($hasComposerRequirements) {
                 // Check that any required Composer dependencies are in the lock file

--- a/tests/Package/Cli/Command/PackageCommandTest.php
+++ b/tests/Package/Cli/Command/PackageCommandTest.php
@@ -32,6 +32,7 @@ class PackageCommandTest extends CommandTestCase
                     '/path/to/package1.zip',
                     '/path/to/package2.zip',
                 ),
+                false,
                 null
             )
             ->once();
@@ -47,6 +48,31 @@ class PackageCommandTest extends CommandTestCase
         ));
     }
 
+    public function testCreatesPackageWithoutCombiningPackages()
+    {
+        $workingDir = __DIR__;
+        $outputDir = __DIR__;
+
+        $this->packageCreator->shouldReceive('create')
+            ->with(
+                $workingDir,
+                $outputDir,
+                'package.zip',
+                array('name' => 'test'),
+                array(),
+                true,
+                null
+            )
+            ->once();
+
+        $this->tester->execute(array(
+            '--working-dir' => $workingDir,
+            '--output-dir' => $outputDir,
+            '--filename' => 'package.zip',
+            '--skip-combine' => true,
+        ));
+    }
+
     public function testCreatesPackageWithPhar()
     {
         $workingDir = __DIR__;
@@ -59,6 +85,7 @@ class PackageCommandTest extends CommandTestCase
                 'package.zip',
                 array('name' => 'test'),
                 array(),
+                false,
                 '/path/to/meteor.phar'
             )
             ->once();


### PR DESCRIPTION
In some circumstances (i.e. development) it may be useful to create a non-combined package. With the `package.combine` configuration in the `meteor.json` file it was not possible to do so as Meteor would always try to combine the required packages. 

This change adds a `--skip-combine` option to the `package` command so no packages will be combined (even if specified with the `--combine` option).
