### PR TITLE
Fix issue with updating migration version files task taking too long

### DIFF
--- a/src/Patch/ServiceContainer/PatchExtension.php
+++ b/src/Patch/ServiceContainer/PatchExtension.php
@@ -332,6 +332,7 @@ class PatchExtension implements ExtensionInterface, ScriptEventProviderInterface
         $definition = new Definition('Meteor\Patch\Task\UpdateMigrationVersionFilesHandler', array(
             new Reference(MigrationsExtension::SERVICE_CONFIGURATION_FACTORY),
             new Reference(MigrationsExtension::SERVICE_VERSION_FILE_MANAGER),
+            new Reference(IOExtension::SERVICE_IO),
         ));
         $definition->addTag(self::TAG_TASK_HANDLER, array(
             'task' => 'Meteor\Patch\Task\UpdateMigrationVersionFiles',

--- a/src/Patch/Strategy/Overwrite/OverwritePatchStrategy.php
+++ b/src/Patch/Strategy/Overwrite/OverwritePatchStrategy.php
@@ -29,6 +29,7 @@ class OverwritePatchStrategy implements PatchStrategyInterface
     {
         $tasks = array();
         $patchFilesDir = $patchDir.'/'.PackageConstants::PATCH_DIR;
+        $backupDir = $installDir.'/backups/'.date('YmdHis');
 
         $tasks[] = new CheckWritePermission($installDir);
         $tasks[] = new DisplayVersionInfo($patchFilesDir, $installDir);
@@ -43,10 +44,10 @@ class OverwritePatchStrategy implements PatchStrategyInterface
         }
 
         $tasks[] = new CheckDiskSpace($installDir);
-        $tasks[] = new UpdateMigrationVersionFiles($patchDir, $installDir);
 
         if (!$options['skip-backup']) {
-            $tasks[] = new BackupFiles(date('YmdHis'), $patchDir, $installDir);
+            $tasks[] = new BackupFiles($backupDir, $patchDir, $installDir);
+            $tasks[] = new UpdateMigrationVersionFiles($backupDir, $patchDir, $installDir);
         }
 
         $tasks[] = new CopyFiles($patchFilesDir, $installDir);

--- a/src/Patch/Task/BackupFiles.php
+++ b/src/Patch/Task/BackupFiles.php
@@ -7,7 +7,7 @@ class BackupFiles
     /**
      * @var string
      */
-    public $timestamp;
+    public $backupDir;
 
     /**
      * @var string
@@ -20,13 +20,13 @@ class BackupFiles
     public $installDir;
 
     /**
-     * @param string $timestamp
+     * @param string $backupDir
      * @param string $patchDir
      * @param string $installDir
      */
-    public function __construct($timestamp, $patchDir, $installDir)
+    public function __construct($backupDir, $patchDir, $installDir)
     {
-        $this->timestamp = $timestamp;
+        $this->backupDir = $backupDir;
         $this->patchDir = $patchDir;
         $this->installDir = $installDir;
     }

--- a/src/Patch/Task/BackupFilesHandler.php
+++ b/src/Patch/Task/BackupFilesHandler.php
@@ -42,26 +42,17 @@ class BackupFilesHandler
      */
     public function handle(BackupFiles $task, array $config)
     {
-        $backupsDir = $task->installDir.'/backups';
-        $this->filesystem->ensureDirectoryExists($backupsDir);
+        $this->io->text(sprintf('Creating backup in <info>%s</>', $task->backupDir));
 
-        $this->io->text(sprintf('Creating backup to <info>%s</>', $task->timestamp));
-
-        $backupDir = $backupsDir.'/'.$task->timestamp;
-        $this->filesystem->ensureDirectoryExists($backupDir);
+        $this->filesystem->ensureDirectoryExists($task->backupDir);
 
         // Copy the files from the install that exist in the patch to the backup
         $this->io->text('Copying files from the install to the backup:');
         $files = $this->filesystem->findFiles($task->patchDir.'/'.PackageConstants::PATCH_DIR);
-        $this->filesystem->copyFiles($files, $task->installDir, $backupDir.'/'.PackageConstants::PATCH_DIR);
-
-        // Copy migration status files so we know what to migrate down to during a rollback
-        $this->io->text('Copying migration status files into the backup:');
-        $files = $this->filesystem->findFiles($task->installDir, array('/*_MIGRATION_NUMBER'));
-        $this->filesystem->copyFiles($files, $task->installDir, $backupDir);
+        $this->filesystem->copyFiles($files, $task->installDir, $task->backupDir.'/'.PackageConstants::PATCH_DIR);
 
         // Copy the meteor.json into the backup
         $configPath = $this->configurationLoader->resolve($task->patchDir);
-        $this->filesystem->copy($configPath, $backupDir.'/meteor.json.package', true);
+        $this->filesystem->copy($configPath, $task->backupDir.'/meteor.json.package', true);
     }
 }

--- a/src/Patch/Task/UpdateMigrationVersionFiles.php
+++ b/src/Patch/Task/UpdateMigrationVersionFiles.php
@@ -7,6 +7,11 @@ class UpdateMigrationVersionFiles
     /**
      * @var string
      */
+    public $backupDir;
+
+    /**
+     * @var string
+     */
     public $patchDir;
 
     /**
@@ -15,11 +20,13 @@ class UpdateMigrationVersionFiles
     public $installDir;
 
     /**
+     * @param string $backupDir
      * @param string $patchDir
      * @param string $installDir
      */
-    public function __construct($patchDir, $installDir)
+    public function __construct($backupDir, $patchDir, $installDir)
     {
+        $this->backupDir = $backupDir;
         $this->patchDir = $patchDir;
         $this->installDir = $installDir;
     }

--- a/tests/Patch/Strategy/Overwrite/OverwritePatchStrategyTest.php
+++ b/tests/Patch/Strategy/Overwrite/OverwritePatchStrategyTest.php
@@ -45,12 +45,13 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDiskSpace', $tasks[5]);
         $this->assertSame('install', $tasks[5]->installDir);
 
-        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[6]);
+        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[6]);
+        $this->assertSame('install/backups/'.date('YmdHis'), $tasks[6]->backupDir);
         $this->assertSame('patch', $tasks[6]->patchDir);
         $this->assertSame('install', $tasks[6]->installDir);
 
-        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[7]);
-        $this->assertNotEmpty($tasks[7]->timestamp);
+        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[7]);
+        $this->assertSame('install/backups/'.date('YmdHis'), $tasks[7]->backupDir);
         $this->assertSame('patch', $tasks[7]->patchDir);
         $this->assertSame('install', $tasks[7]->installDir);
 
@@ -82,8 +83,8 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDatabaseConnection', $tasks[2]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDiskSpace', $tasks[3]);
-        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[4]);
-        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[5]);
+        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[4]);
+        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[5]);
         $this->assertInstanceOf('Meteor\Patch\Task\CopyFiles', $tasks[6]);
         $this->assertInstanceOf('Meteor\Patch\Task\MigrateUp', $tasks[7]);
         $this->assertInstanceOf('Meteor\Patch\Task\MigrateUp', $tasks[8]);
@@ -104,8 +105,8 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Meteor\Patch\Task\CheckVersion', $tasks[3]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDatabaseConnection', $tasks[4]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDiskSpace', $tasks[5]);
-        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[6]);
-        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[7]);
+        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[6]);
+        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[7]);
         $this->assertInstanceOf('Meteor\Patch\Task\CopyFiles', $tasks[8]);
         $this->assertInstanceOf('Meteor\Patch\Task\MigrateUp', $tasks[9]);
     }
@@ -125,8 +126,8 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Meteor\Patch\Task\CheckVersion', $tasks[3]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDatabaseConnection', $tasks[4]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDiskSpace', $tasks[5]);
-        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[6]);
-        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[7]);
+        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[6]);
+        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[7]);
         $this->assertInstanceOf('Meteor\Patch\Task\CopyFiles', $tasks[8]);
         $this->assertInstanceOf('Meteor\Patch\Task\MigrateUp', $tasks[9]);
     }
@@ -145,8 +146,8 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Meteor\Patch\Task\CheckModuleCmsDependency', $tasks[2]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckVersion', $tasks[3]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDiskSpace', $tasks[4]);
-        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[5]);
-        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[6]);
+        $this->assertInstanceOf('Meteor\Patch\Task\BackupFiles', $tasks[5]);
+        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[6]);
         $this->assertInstanceOf('Meteor\Patch\Task\CopyFiles', $tasks[7]);
     }
 
@@ -165,10 +166,9 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Meteor\Patch\Task\CheckVersion', $tasks[3]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDatabaseConnection', $tasks[4]);
         $this->assertInstanceOf('Meteor\Patch\Task\CheckDiskSpace', $tasks[5]);
-        $this->assertInstanceOf('Meteor\Patch\Task\UpdateMigrationVersionFiles', $tasks[6]);
-        $this->assertInstanceOf('Meteor\Patch\Task\CopyFiles', $tasks[7]);
+        $this->assertInstanceOf('Meteor\Patch\Task\CopyFiles', $tasks[6]);
+        $this->assertInstanceOf('Meteor\Patch\Task\MigrateUp', $tasks[7]);
         $this->assertInstanceOf('Meteor\Patch\Task\MigrateUp', $tasks[8]);
-        $this->assertInstanceOf('Meteor\Patch\Task\MigrateUp', $tasks[9]);
     }
 
     public function testRollback()

--- a/tests/Patch/Task/BackupFilesHandlerTest.php
+++ b/tests/Patch/Task/BackupFilesHandlerTest.php
@@ -28,19 +28,6 @@ class BackupFilesHandlerTest extends \PHPUnit_Framework_TestCase
         $this->handler = new BackupFilesHandler($this->filesystem, $this->configurationLoader, $this->io);
     }
 
-    public function testCreatesBackupDirectory()
-    {
-        $this->filesystem->shouldReceive('ensureDirectoryExists')
-            ->with('install/backups')
-            ->once();
-
-        $this->filesystem->shouldReceive('ensureDirectoryExists')
-            ->with('install/backups/20160701000000')
-            ->once();
-
-        $this->handler->handle(new BackupFiles('20160701000000', 'patch', 'install'), array());
-    }
-
     public function testCopiesFilesFromInstallIntoBackupDirectory()
     {
         $patchFiles = array('VERSION');
@@ -53,17 +40,7 @@ class BackupFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->with($patchFiles, 'install', 'install/backups/20160701000000/to_patch')
             ->once();
 
-        $migrationFiles = array('CORE_MIGRATION_VERSION');
-        $this->filesystem->shouldReceive('findFiles')
-            ->with('install', array('/*_MIGRATION_NUMBER'))
-            ->andReturn($migrationFiles)
-            ->once();
-
-        $this->filesystem->shouldReceive('copyFiles')
-            ->with($migrationFiles, 'install', 'install/backups/20160701000000')
-            ->once();
-
-        $this->handler->handle(new BackupFiles('20160701000000', 'patch', 'install'), array());
+        $this->handler->handle(new BackupFiles('install/backups/20160701000000', 'patch', 'install'), array());
     }
 
     public function testCopiesMeteorConfigIntoBackupFromPatch()
@@ -77,6 +54,6 @@ class BackupFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->with('patch/meteor.json.package', 'install/backups/20160701000000/meteor.json.package', true)
             ->once();
 
-        $this->handler->handle(new BackupFiles('20160701000000', 'patch', 'install'), array());
+        $this->handler->handle(new BackupFiles('install/backups/20160701000000', 'patch', 'install'), array());
     }
 }

--- a/tests/Patch/Task/UpdateMigrationVersionFilesHandlerTest.php
+++ b/tests/Patch/Task/UpdateMigrationVersionFilesHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Meteor\Patch\Task;
 
+use Meteor\IO\NullIO;
 use Meteor\Migrations\Configuration\ConfigurationFactory;
 use Meteor\Migrations\MigrationsConstants;
 use Meteor\Migrations\Version\VersionFileManager;
@@ -19,7 +20,8 @@ class UpdateMigrationVersionFilesHandlerTest extends \PHPUnit_Framework_TestCase
         $this->versionFileManager = Mockery::mock('Meteor\Migrations\Version\VersionFileManager');
         $this->handler = new UpdateMigrationVersionFilesHandler(
             $this->configurationFactory,
-            $this->versionFileManager
+            $this->versionFileManager,
+            new NullIO()
         );
     }
 
@@ -42,7 +44,7 @@ class UpdateMigrationVersionFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->versionFileManager->shouldReceive('setCurrentVersion')
-            ->with('20160701000000', 'install', 'Migrations', VersionFileManager::DATABASE_MIGRATION)
+            ->with('20160701000000', 'backup', 'Migrations', VersionFileManager::DATABASE_MIGRATION)
             ->once();
 
         $fileConfiguration = Mockery::mock('Meteor\Migrations\Configuration\FileConfiguration', array(
@@ -55,10 +57,10 @@ class UpdateMigrationVersionFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->versionFileManager->shouldReceive('setCurrentVersion')
-            ->with('20160701000000', 'install', 'Migrations', VersionFileManager::FILE_MIGRATION)
+            ->with('20160701000000', 'backup', 'Migrations', VersionFileManager::FILE_MIGRATION)
             ->once();
 
-        $this->handler->handle(new UpdateMigrationVersionFiles('patch', 'install'), $config);
+        $this->handler->handle(new UpdateMigrationVersionFiles('backup', 'patch', 'install'), $config);
     }
 
     public function testSetsCurrentVersionForCombinedPackageMigrations()
@@ -84,7 +86,7 @@ class UpdateMigrationVersionFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->versionFileManager->shouldReceive('setCurrentVersion')
-            ->with('20160701000000', 'install', 'Migrations', VersionFileManager::DATABASE_MIGRATION)
+            ->with('20160701000000', 'backup', 'Migrations', VersionFileManager::DATABASE_MIGRATION)
             ->once();
 
         $fileConfiguration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', array(
@@ -97,9 +99,9 @@ class UpdateMigrationVersionFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->versionFileManager->shouldReceive('setCurrentVersion')
-            ->with('20160701000000', 'install', 'Migrations', VersionFileManager::FILE_MIGRATION)
+            ->with('20160701000000', 'backup', 'Migrations', VersionFileManager::FILE_MIGRATION)
             ->once();
 
-        $this->handler->handle(new UpdateMigrationVersionFiles('patch', 'install'), $config);
+        $this->handler->handle(new UpdateMigrationVersionFiles('backup', 'patch', 'install'), $config);
     }
 }


### PR DESCRIPTION
Fixes #12 

The backup directory is now passed to the `UpdateMigrationVersionFilesHandler` so it can simply write the files out directly to the backup. This removes the need to search for migration status files that was the cause of the performance issue.
