### PR TITLE
Script recursion detection

### DIFF
--- a/src/Scripts/ServiceContainer/ScriptsExtension.php
+++ b/src/Scripts/ServiceContainer/ScriptsExtension.php
@@ -77,21 +77,19 @@ class ScriptsExtension implements ExtensionInterface
         ->end();
     }
 
-    public function hasInfiniteRecursion(array $scripts, $parentName = null)
+    public function hasInfiniteRecursion(array $scripts)
     {
         foreach ($scripts as $name => $commands) {
-            foreach ($commands as $command) {
+            foreach ($commands as $idOrName => $command) {
+                $parentName = (is_string($idOrName) ? $idOrName : $name);
                 if (strpos($command, '@') === 0) {
                     $command = substr($command, 1);
                     if ($command === $parentName) {
                         return true;
                     }
-
-                    return $this->hasInfiniteRecursion($scripts[$command]);
                 }
             }
         }
-
         return false;
     }
 

--- a/src/Scripts/ServiceContainer/ScriptsExtension.php
+++ b/src/Scripts/ServiceContainer/ScriptsExtension.php
@@ -80,11 +80,10 @@ class ScriptsExtension implements ExtensionInterface
     public function hasInfiniteRecursion(array $scripts)
     {
         foreach ($scripts as $name => $commands) {
-            foreach ($commands as $idOrName => $command) {
-                $parentName = (is_string($idOrName) ? $idOrName : $name);
+            foreach ($commands as $command) {
                 if (strpos($command, '@') === 0) {
                     $command = substr($command, 1);
-                    if ($command === $parentName) {
+                    if ($command === $name) {
                         return true;
                     }
                 }


### PR DESCRIPTION
The `$parentName` variable isn't ever used, so the comparison on [L86](https://github.com/jadu/meteor/compare/feature/script-recursion-detection?expand=1#diff-c4da6ca9bfd3deebc29af7a09c99b562R86) would never return `true`.

I've modified this to use the name of the script as the comparison against the value of the command minus the `@` character.

I've also removed the recursion of calling `hasInfiniteRecursion` back on it's self as this throws warning because the value of `$scripts[$command]` is not a multi-dimensional array.

Tests have not been modified because the check for infinite recursion is replicated within the [ScriptRunner](https://github.com/jadu/meteor/blob/master/src/Scripts/ScriptRunner.php#L78) and the `hasInfiniteRecursion` method isn't ever checked within any tests - might be a good idea to test this, though.
