### PR TITLE
Fix script circular references

### DIFF
--- a/src/Scripts/ScriptRunner.php
+++ b/src/Scripts/ScriptRunner.php
@@ -4,7 +4,6 @@ namespace Meteor\Scripts;
 
 use Meteor\IO\IOInterface;
 use Meteor\Process\ProcessRunner;
-use RuntimeException;
 
 class ScriptRunner
 {
@@ -67,21 +66,17 @@ class ScriptRunner
 
         $result = true;
         foreach ($this->scripts[$scriptName] as $script) {
-            $result = $this->runScript($scriptName, $script);
+            $result = $this->runScript($script);
         }
 
         return $result;
     }
 
-    private function runScript($scriptName, $script)
+    private function runScript($script)
     {
         if (strpos($script, '@') === 0) {
-            $script = substr($script, 1);
-            if ($scriptName === $script) {
-                throw new RuntimeException(sprintf('Infinite recursion detected in script "%s"', $scriptName));
-            }
-
-            return $this->run($script);
+            // NB: Infinite recursion detection happens when processing the config
+            return $this->run(substr($script, 1));
         }
 
         $this->processRunner->run($script, $this->getWorkingDir());

--- a/tests/Scripts/Exception/CircularScriptReferenceException.php
+++ b/tests/Scripts/Exception/CircularScriptReferenceException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Meteor\Scripts\Exception;
+
+class CircularScriptReferenceException extends ScriptReferenceException
+{
+}

--- a/tests/Scripts/Exception/ScriptReferenceException.php
+++ b/tests/Scripts/Exception/ScriptReferenceException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Meteor\Scripts\Exception;
+
+use Exception;
+
+class ScriptReferenceException extends Exception
+{
+}

--- a/tests/Scripts/ScriptRunnerTest.php
+++ b/tests/Scripts/ScriptRunnerTest.php
@@ -78,17 +78,4 @@ class ScriptRunnerTest extends \PHPUnit_Framework_TestCase
 
         $scriptRunner->run('test');
     }
-
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Infinite recursion
-     */
-    public function testPreventInfiniteLoop()
-    {
-        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), array(
-            'test' => array('@test'),
-        ));
-
-        $scriptRunner->run('test');
-    }
 }

--- a/tests/Scripts/ServiceContainer/ScriptsExtensionTest.php
+++ b/tests/Scripts/ServiceContainer/ScriptsExtensionTest.php
@@ -70,7 +70,7 @@ class ScriptsExtensionTest extends ExtensionTestCase
 
     /**
      * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Infinite recursion detected in scripts
+     * @expectedExceptionMessage Circular reference detected in "test" to "test"
      */
     public function testConfigPreventsInfiniteRecursion()
     {
@@ -83,7 +83,7 @@ class ScriptsExtensionTest extends ExtensionTestCase
 
     /**
      * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Infinite recursion detected in scripts
+     * @expectedExceptionMessage Circular reference detected in "test2" to "test1"
      */
     public function testConfigPreventsInfiniteRecursionWithScriptReferences()
     {
@@ -91,6 +91,23 @@ class ScriptsExtensionTest extends ExtensionTestCase
             'scripts' => array(
                 'test1' => array('@test2'),
                 'test2' => array('@test1'),
+            ),
+        ));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Circular reference detected in "test5" to "test1"
+     */
+    public function testConfigPreventsInfiniteRecursionWithDeepScriptReferences()
+    {
+        $this->processConfiguration(array(
+            'scripts' => array(
+                'test1' => array('@test2'),
+                'test2' => array('@test3'),
+                'test3' => array('@test4'),
+                'test4' => array('@test5'),
+                'test5' => array('@test1'),
             ),
         ));
     }

--- a/tests/Scripts/ServiceContainer/ScriptsExtensionTest.php
+++ b/tests/Scripts/ServiceContainer/ScriptsExtensionTest.php
@@ -70,12 +70,27 @@ class ScriptsExtensionTest extends ExtensionTestCase
 
     /**
      * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Infinite recursion detected in scripts
      */
     public function testConfigPreventsInfiniteRecursion()
     {
         $this->processConfiguration(array(
             'scripts' => array(
                 'test' => array('@test'),
+            ),
+        ));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Infinite recursion detected in scripts
+     */
+    public function testConfigPreventsInfiniteRecursionWithScriptReferences()
+    {
+        $this->processConfiguration(array(
+            'scripts' => array(
+                'test1' => array('@test2'),
+                'test2' => array('@test1'),
             ),
         ));
     }


### PR DESCRIPTION
A script definition can have a circular reference that is not caught by the config validation.

A failing test has been added in this branch.
