### PR TITLE
Increase minimum required PHP version to 5.6

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,7 +13,7 @@ $config->finder($finder);
 $config->level(FixerInterface::SYMFONY_LEVEL);
 $config->fixers([
     '-phpdoc_params',
-    'long_array_syntax',
+    'short_array_syntax',
     'ordered_use',
     'unused_use',
     'strict',

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: php
 
 php:
-  - 5.3
   - 5.6
   - 7.0
 
 before_script:
   - wget http://getcomposer.org/composer.phar
-  - if [[ "$PHP" > "5.3" ]]; then composer require satooshi/php-coveralls:dev-master; fi
   - php composer.phar install --no-interaction
+  - php composer.phar require satooshi/php-coveralls:dev-master
   - php composer.phar dump-autoload --optimize
 
 script:
@@ -16,7 +15,7 @@ script:
   - ./vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
 
 after_script:
-  - if [[ "$PHP" > "5.3" ]]; then travis_retry php vendor/bin/coveralls -v; fi
+  - travis_retry php vendor/bin/coveralls -v
 
 matrix:
   fast_finish: true

--- a/box.json.dist
+++ b/box.json.dist
@@ -11,7 +11,6 @@
     "finder": [
         {
             "exclude": [
-                "/kherge",
                 "/mikey179",
                 "/mockery",
                 "/phpunit",

--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,25 @@
 {
-    "name": "jadu/meteor2",
+    "name": "jadu/meteor",
     "type": "library",
     "require": {
-        "php": ">=5.3.3",
-        "symfony/class-loader": "^2.6",
-        "symfony/config": "^2.6",
-        "symfony/console": "^2.6",
-        "symfony/dependency-injection": "^2.6",
-        "symfony/event-dispatcher": "^2.6",
-        "symfony/finder": "^2.6",
-        "symfony/process": "^2.6",
-        "symfony/options-resolver": "^2.6",
-        "symfony/yaml": "^2.6",
+        "php": ">=5.6",
+        "symfony/class-loader": "^3.1",
+        "symfony/config": "^3.1",
+        "symfony/console": "^3.1",
+        "symfony/dependency-injection": "^3.1",
+        "symfony/event-dispatcher": "^3.1",
+        "symfony/finder": "^3.1",
+        "symfony/process": "^3.1",
+        "symfony/options-resolver": "^3.1",
+        "symfony/yaml": "^3.1",
         "doctrine/dbal": "^2.5",
-        "doctrine/migrations": "^1.0.0@alpha",
+        "doctrine/migrations": "^1.0.0",
         "composer/semver": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "*",
         "mockery/mockery": "*",
-        "mikey179/vfsStream": "*",
-        "kherge/box": "^2.6"
+        "mikey179/vfsStream": "*"
     },
     "autoload": {
         "psr-4": {
@@ -35,8 +34,8 @@
     },
     "config": {
         "platform": {
-            "php": "5.3.3"
+            "php": "5.6"
         }
     },
-    "bin": ["bin/meteor2"]
+    "bin": ["bin/meteor"]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "19c678988b43e00f742f82cd327b008a",
-    "content-hash": "1bb11d5b913f2c299a35274f98789fe9",
+    "hash": "a4ee2df51363e63ce841f1324ecdad10",
+    "content-hash": "04acb92c1416f61f8e86acbadfcf74f3",
     "packages": [
         {
             "name": "composer/semver",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "03c9de5aa25e7672c4ad251eeaba0c47a06c8b98"
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/03c9de5aa25e7672c4ad251eeaba0c47a06c8b98",
-                "reference": "03c9de5aa25e7672c4ad251eeaba0c47a06c8b98",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
                 "shasum": ""
             },
             "require": {
@@ -67,39 +67,39 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-06-02 09:04:51"
+            "time": "2016-08-30 16:08:34"
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.2.7",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535"
+                "reference": "30e07cf03edc3cd3ef579d0dd4dd8c58250799a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/30e07cf03edc3cd3ef579d0dd4dd8c58250799a5",
+                "reference": "30e07cf03edc3cd3ef579d0dd4dd8c58250799a5",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
-                "php": ">=5.3.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^5.6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Annotations\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -135,37 +135,37 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2016-10-24 11:45:47"
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.5.4",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "47cdc76ceb95cc591d9c79a36dc3794975b5d136"
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/47cdc76ceb95cc591d9c79a36dc3794975b5d136",
-                "reference": "47cdc76ceb95cc591d9c79a36dc3794975b5d136",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "~5.5|~7.0"
             },
             "conflict": {
                 "doctrine/common": ">2.2,<2.4"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=3.7",
+                "phpunit/phpunit": "~4.8|~5.0",
                 "predis/predis": "~1.0",
                 "satooshi/php-coveralls": "~0.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -205,7 +205,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-19 05:03:47"
+            "time": "2015-12-31 16:37:02"
         },
         {
             "name": "doctrine/collections",
@@ -275,16 +275,16 @@
         },
         {
             "name": "doctrine/common",
-            "version": "v2.5.3",
+            "version": "v2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "10f1f19651343f87573129ca970aef1a47a6f29e"
+                "reference": "a579557bc689580c19fee4e27487a67fe60defc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/10f1f19651343f87573129ca970aef1a47a6f29e",
-                "reference": "10f1f19651343f87573129ca970aef1a47a6f29e",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/a579557bc689580c19fee4e27487a67fe60defc0",
+                "reference": "a579557bc689580c19fee4e27487a67fe60defc0",
                 "shasum": ""
             },
             "require": {
@@ -293,20 +293,20 @@
                 "doctrine/collections": "1.*",
                 "doctrine/inflector": "1.*",
                 "doctrine/lexer": "1.*",
-                "php": ">=5.3.2"
+                "php": "~5.5|~7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~3.7"
+                "phpunit/phpunit": "~4.8|~5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5.x-dev"
+                    "dev-master": "2.7.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -344,20 +344,20 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-12-25 13:10:16"
+            "time": "2015-12-25 13:18:31"
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.5.4",
+            "version": "v2.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769"
+                "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
-                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
+                "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
                 "shasum": ""
             },
             "require": {
@@ -366,7 +366,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "4.*",
-                "symfony/console": "2.*"
+                "symfony/console": "2.*||^3.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -415,7 +415,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2016-01-05 22:11:12"
+            "time": "2016-09-09 19:13:33"
         },
         {
             "name": "doctrine/inflector",
@@ -540,38 +540,49 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "v1.0.0-alpha3",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "d2d18ef671b47a7d48fae54806adac87e82fe8e9"
+                "reference": "0d0ff5da10c5d30846da32060bd9e357abf70a05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/d2d18ef671b47a7d48fae54806adac87e82fe8e9",
-                "reference": "d2d18ef671b47a7d48fae54806adac87e82fe8e9",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/0d0ff5da10c5d30846da32060bd9e357abf70a05",
+                "reference": "0d0ff5da10c5d30846da32060bd9e357abf70a05",
                 "shasum": ""
             },
             "require": {
-                "doctrine/dbal": "~2.0",
-                "php": ">=5.3.2"
+                "doctrine/dbal": "~2.2",
+                "ocramius/proxy-manager": "^1.0|^2.0",
+                "php": "^5.5|^7.0",
+                "symfony/console": "~2.3|~3.0",
+                "symfony/yaml": "~2.3|~3.0"
             },
             "require-dev": {
-                "symfony/console": "2.*",
-                "symfony/yaml": "2.*"
+                "doctrine/coding-standard": "dev-master",
+                "doctrine/orm": "2.*",
+                "jdorn/sql-formatter": "~1.1",
+                "johnkary/phpunit-speedtrap": "~1.0@dev",
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "~4.7",
+                "satooshi/php-coveralls": "0.6.*"
             },
             "suggest": {
-                "symfony/console": "to run the migration from the console"
+                "jdorn/sql-formatter": "Allows to generate formatted SQL with the diff command."
             },
+            "bin": [
+                "bin/doctrine-migrations"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "v1.5.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\DBAL\\Migrations": "lib"
+                "psr-4": {
+                    "Doctrine\\DBAL\\Migrations\\": "lib/Doctrine/DBAL/Migrations"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -586,6 +597,10 @@
                 {
                     "name": "Jonathan Wage",
                     "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Michael Simonson",
+                    "email": "contact@mikesimonson.com"
                 }
             ],
             "description": "Database Schema migrations using Doctrine DBAL",
@@ -594,40 +609,155 @@
                 "database",
                 "migrations"
             ],
-            "time": "2015-03-22 13:09:02"
+            "time": "2016-03-14 12:29:11"
         },
         {
-            "name": "symfony/class-loader",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/ClassLoader",
+            "name": "ocramius/proxy-manager",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/class-loader.git",
-                "reference": "c5311911ee5bf1c4bfcd8b5788037e7534e4e17d"
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/c5311911ee5bf1c4bfcd8b5788037e7534e4e17d",
-                "reference": "c5311911ee5bf1c4bfcd8b5788037e7534e4e17d",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/57e9272ec0e8deccf09421596e0e2252df440e11",
+                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.3",
+                "zendframework/zend-code": ">2.2.5,<3.0"
             },
             "require-dev": {
-                "symfony/finder": "~2.0,>=2.0.5",
-                "symfony/phpunit-bridge": "~2.7"
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "1.5.*"
+            },
+            "suggest": {
+                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
+                "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
+                "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
+                "zendframework/zend-stdlib": "To use the hydrator proxy",
+                "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
-                    "Symfony\\Component\\ClassLoader\\": ""
+                    "ProxyManager\\": "src"
                 }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
+            "homepage": "https://github.com/Ocramius/ProxyManager",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "time": "2015-08-09 04:28:19"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10 12:19:37"
+        },
+        {
+            "name": "symfony/class-loader",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/class-loader.git",
+                "reference": "bcb072aba46ddf3b1a496438c63be6be647739aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/bcb072aba46ddf3b1a496438c63be6be647739aa",
+                "reference": "bcb072aba46ddf3b1a496438c63be6be647739aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "symfony/finder": "~2.8|~3.0",
+                "symfony/polyfill-apcu": "~1.1"
+            },
+            "suggest": {
+                "symfony/polyfill-apcu": "For using ApcClassLoader on HHVM"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ClassLoader\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -645,40 +775,42 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-25 11:21:15"
+            "time": "2016-09-06 23:30:54"
         },
         {
             "name": "symfony/config",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/Config",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "0ca496cbe208fc37c4cf3415ebb3056e0963115b"
+                "reference": "949e7e846743a7f9e46dc50eb639d5fde1f53341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/0ca496cbe208fc37c4cf3415ebb3056e0963115b",
-                "reference": "0ca496cbe208fc37c4cf3415ebb3056e0963115b",
+                "url": "https://api.github.com/repos/symfony/config/zipball/949e7e846743a7f9e46dc50eb639d5fde1f53341",
+                "reference": "949e7e846743a7f9e46dc50eb639d5fde1f53341",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "symfony/filesystem": "~2.3"
+                "php": ">=5.5.9",
+                "symfony/filesystem": "~2.8|~3.0"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Config\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -696,31 +828,31 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-08 05:59:48"
+            "time": "2016-09-25 08:27:07"
         },
         {
             "name": "symfony/console",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/Console",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359"
+                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0e5e18ae09d3f5c06367759be940e9ed3f568359",
-                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
+                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5.9",
+                "symfony/debug": "~2.8|~3.0",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/process": "~2.1"
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -730,13 +862,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Console\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -754,50 +889,106 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-26 09:08:40"
+            "time": "2016-09-28 00:11:12"
         },
         {
-            "name": "symfony/dependency-injection",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/DependencyInjection",
+            "name": "symfony/debug",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e"
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e",
-                "reference": "d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5.9",
+                "psr/log": "~1.0"
             },
             "conflict": {
-                "symfony/expression-language": "<2.6"
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
             },
             "require-dev": {
-                "symfony/config": "~2.2",
-                "symfony/expression-language": "~2.6",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/yaml": "~2.1"
+                "symfony/class-loader": "~2.8|~3.0",
+                "symfony/http-kernel": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-06 11:02:40"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "8fa4be9a36f41e49b0c3969678c41c81ed463816"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/8fa4be9a36f41e49b0c3969678c41c81ed463816",
+                "reference": "8fa4be9a36f41e49b0c3969678c41c81ed463816",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "symfony/config": "~2.8|~3.0",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/yaml": "~2.8.7|~3.0.7|~3.1.1|~3.2"
             },
             "suggest": {
                 "symfony/config": "",
+                "symfony/expression-language": "For using expressions in service container configuration",
                 "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
                 "symfony/yaml": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\DependencyInjection\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -815,33 +1006,31 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-22 10:08:40"
+            "time": "2016-09-24 15:56:48"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/EventDispatcher",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "672593bc4b0043a0acf91903bb75a1c82d8f2e02"
+                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/672593bc4b0043a0acf91903bb75a1c82d8f2e02",
-                "reference": "672593bc4b0043a0acf91903bb75a1c82d8f2e02",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
+                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5.9"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/stopwatch": "~2.3"
+                "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~2.8|~3.0",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/stopwatch": "~2.8|~3.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -850,13 +1039,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -874,39 +1066,38 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:18:45"
+            "time": "2016-07-19 10:45:57"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/Filesystem",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "823c035b1a5c13a4924e324d016eb07e70f94735"
+                "reference": "682fd8fdb3135fdf05fc496a01579ccf6c85c0e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/823c035b1a5c13a4924e324d016eb07e70f94735",
-                "reference": "823c035b1a5c13a4924e324d016eb07e70f94735",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/682fd8fdb3135fdf05fc496a01579ccf6c85c0e5",
+                "reference": "682fd8fdb3135fdf05fc496a01579ccf6c85c0e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -924,39 +1115,38 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-08 05:59:48"
+            "time": "2016-09-14 00:18:46"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/Finder",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "203a10f928ae30176deeba33512999233181dd28"
+                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/203a10f928ae30176deeba33512999233181dd28",
-                "reference": "203a10f928ae30176deeba33512999233181dd28",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
+                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -974,39 +1164,38 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:02:48"
+            "time": "2016-09-28 00:11:12"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/OptionsResolver",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "31e56594cee489e9a235b852228b0598b52101c1"
+                "reference": "30605874d99af0cde6c41fd39e18546330c38100"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/31e56594cee489e9a235b852228b0598b52101c1",
-                "reference": "31e56594cee489e9a235b852228b0598b52101c1",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/30605874d99af0cde6c41fd39e18546330c38100",
+                "reference": "30605874d99af0cde6c41fd39e18546330c38100",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\OptionsResolver\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1029,39 +1218,97 @@
                 "configuration",
                 "options"
             ],
-            "time": "2015-05-13 11:33:56"
+            "time": "2016-05-12 15:59:27"
         },
         {
-            "name": "symfony/process",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/Process",
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "57f1e88bb5dafa449b83f9f265b11d52d517b3e9"
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/57f1e88bb5dafa449b83f9f265b11d52d517b3e9",
-                "reference": "57f1e88bb5dafa449b83f9f265b11d52d517b3e9",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+            "suggest": {
+                "ext-mbstring": "For best performance"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\Process\\": ""
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-05-18 14:26:46"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/66de154ae86b1a07001da9fbffd620206e4faf94",
+                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1079,39 +1326,38 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-30 16:10:16"
+            "time": "2016-09-29 14:13:09"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c044d1744b8e91aaaa0d9bac683ab87ec7cbf359"
+                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c044d1744b8e91aaaa0d9bac683ab87ec7cbf359",
-                "reference": "c044d1744b8e91aaaa0d9bac683ab87ec7cbf359",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/368b9738d4033c8b93454cb0dbd45d305135a6d3",
+                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1129,7 +1375,113 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-26 08:59:42"
+            "time": "2016-09-25 08:27:07"
+        },
+        {
+            "name": "zendframework/zend-code",
+            "version": "2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-code.git",
+                "reference": "95033f061b083e16cdee60530ec260d7d628b887"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/95033f061b083e16cdee60530ec260d7d628b887",
+                "reference": "95033f061b083e16cdee60530ec260d7d628b887",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || 7.0.0 - 7.0.4 || ^7.0.6",
+                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "^4.8.21",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "zendframework/zend-stdlib": "Zend\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev",
+                    "dev-develop": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides facilities to generate arbitrary code using an object oriented interface",
+            "homepage": "https://github.com/zendframework/zend-code",
+            "keywords": [
+                "code",
+                "zf2"
+            ],
+            "time": "2016-04-20 17:26:42"
+        },
+        {
+            "name": "zendframework/zend-eventmanager",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-eventmanager.git",
+                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/5c80bdee0e952be112dcec0968bad770082c3a6e",
+                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.0",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://github.com/zendframework/zend-eventmanager",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "zf2"
+            ],
+            "time": "2016-02-18 20:53:00"
         }
     ],
     "packages-dev": [
@@ -1231,475 +1583,6 @@
                 "test"
             ],
             "time": "2015-05-11 14:41:42"
-        },
-        {
-            "name": "herrera-io/annotations",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kherge-abandoned/php-annotations.git",
-                "reference": "7d8b9a536da7f12aad8de7f28b2cb5266bde8da1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kherge-abandoned/php-annotations/zipball/7d8b9a536da7f12aad8de7f28b2cb5266bde8da1",
-                "reference": "7d8b9a536da7f12aad8de7f28b2cb5266bde8da1",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/annotations": "~1.0",
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "herrera-io/phpunit-test-case": "1.*",
-                "phpunit/phpunit": "3.7.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Herrera\\Annotations": "src/lib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kevin Herrera",
-                    "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
-                }
-            ],
-            "description": "A tokenizer for Doctrine annotations.",
-            "homepage": "https://github.com/herrera-io/php-annotations",
-            "keywords": [
-                "annotations",
-                "doctrine",
-                "tokenizer"
-            ],
-            "time": "2014-02-03 17:34:08"
-        },
-        {
-            "name": "herrera-io/box",
-            "version": "1.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/box-project/box2-lib.git",
-                "reference": "b55dceb5c65cc831e94ec0786b0b9b15f1103e8e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/box-project/box2-lib/zipball/b55dceb5c65cc831e94ec0786b0b9b15f1103e8e",
-                "reference": "b55dceb5c65cc831e94ec0786b0b9b15f1103e8e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-phar": "*",
-                "phine/path": "~1.0",
-                "php": ">=5.3.3",
-                "tedivm/jshrink": "~1.0"
-            },
-            "require-dev": {
-                "herrera-io/annotations": "~1.0",
-                "herrera-io/phpunit-test-case": "1.*",
-                "mikey179/vfsstream": "1.1.0",
-                "phpseclib/phpseclib": "~0.3",
-                "phpunit/phpunit": "3.7.*"
-            },
-            "suggest": {
-                "herrera-io/annotations": "For compacting annotated docblocks.",
-                "phpseclib/phpseclib": "For verifying OpenSSL signed phars without the phar extension."
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Herrera\\Box": "src/lib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kevin Herrera",
-                    "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
-                }
-            ],
-            "description": "A library for simplifying the PHAR build process.",
-            "homepage": "https://github.com/box-project/box2-lib",
-            "keywords": [
-                "phar"
-            ],
-            "time": "2014-12-03 23:26:45"
-        },
-        {
-            "name": "herrera-io/json",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kherge-abandoned/php-json.git",
-                "reference": "60c696c9370a1e5136816ca557c17f82a6fa83f1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kherge-abandoned/php-json/zipball/60c696c9370a1e5136816ca557c17f82a6fa83f1",
-                "reference": "60c696c9370a1e5136816ca557c17f82a6fa83f1",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "justinrainbow/json-schema": ">=1.0,<2.0-dev",
-                "php": ">=5.3.3",
-                "seld/jsonlint": ">=1.0,<2.0-dev"
-            },
-            "require-dev": {
-                "herrera-io/phpunit-test-case": "1.*",
-                "mikey179/vfsstream": "1.1.0",
-                "phpunit/phpunit": "3.7.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/lib/json_version.php"
-                ],
-                "psr-0": {
-                    "Herrera\\Json": "src/lib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kevin Herrera",
-                    "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
-                }
-            ],
-            "description": "A library for simplifying JSON linting and validation.",
-            "homepage": "http://herrera-io.github.com/php-json",
-            "keywords": [
-                "json",
-                "lint",
-                "schema",
-                "validate"
-            ],
-            "time": "2013-10-30 16:51:34"
-        },
-        {
-            "name": "herrera-io/phar-update",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kherge-abandoned/php-phar-update.git",
-                "reference": "15643c90d3d43620a4f45c910e6afb7a0ad4b488"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kherge-abandoned/php-phar-update/zipball/15643c90d3d43620a4f45c910e6afb7a0ad4b488",
-                "reference": "15643c90d3d43620a4f45c910e6afb7a0ad4b488",
-                "shasum": ""
-            },
-            "require": {
-                "herrera-io/json": "1.*",
-                "herrera-io/version": "1.*",
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "herrera-io/phpunit-test-case": "1.*",
-                "mikey179/vfsstream": "1.1.0",
-                "phpunit/phpunit": "3.7.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/lib/constants.php"
-                ],
-                "psr-0": {
-                    "Herrera\\Phar\\Update": "src/lib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kevin Herrera",
-                    "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
-                }
-            ],
-            "description": "A library for self-updating Phars.",
-            "homepage": "http://herrera-io.github.com/php-phar-update",
-            "keywords": [
-                "phar",
-                "update"
-            ],
-            "time": "2013-11-09 17:13:13"
-        },
-        {
-            "name": "herrera-io/version",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kherge-abandoned/php-version.git",
-                "reference": "d39d9642b92a04d8b8a28b871b797a35a2545e85"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kherge-abandoned/php-version/zipball/d39d9642b92a04d8b8a28b871b797a35a2545e85",
-                "reference": "d39d9642b92a04d8b8a28b871b797a35a2545e85",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "herrera-io/phpunit-test-case": "1.*",
-                "phpunit/phpunit": "3.7.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Herrera\\Version": "src/lib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kevin Herrera",
-                    "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
-                }
-            ],
-            "description": "A library for creating, editing, and comparing semantic versioning numbers.",
-            "homepage": "http://github.com/herrera-io/php-version",
-            "keywords": [
-                "semantic",
-                "version"
-            ],
-            "time": "2014-05-27 05:29:25"
-        },
-        {
-            "name": "justinrainbow/json-schema",
-            "version": "v1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "f9e27c3e202faf14fd581ef41355d83bb4b7eb7d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/f9e27c3e202faf14fd581ef41355d83bb4b7eb7d",
-                "reference": "f9e27c3e202faf14fd581ef41355d83bb4b7eb7d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "require-dev": {
-                "json-schema/json-schema-test-suite": "1.1.0",
-                "phpdocumentor/phpdocumentor": "~2",
-                "phpunit/phpunit": "~3.7"
-            },
-            "bin": [
-                "bin/validate-json"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "JsonSchema\\": "src/JsonSchema/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Bruno Prieto Reis",
-                    "email": "bruno.p.reis@gmail.com"
-                },
-                {
-                    "name": "Justin Rainbow",
-                    "email": "justin.rainbow@gmail.com"
-                },
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                },
-                {
-                    "name": "Robert Schönthal",
-                    "email": "seroscho@googlemail.com"
-                }
-            ],
-            "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
-            "keywords": [
-                "json",
-                "schema"
-            ],
-            "time": "2016-01-06 14:37:04"
-        },
-        {
-            "name": "kherge/amend",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/box-project/amend.git",
-                "reference": "16cc7665e847d09cc9ccadec546a2de05c40e8f4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/box-project/amend/zipball/16cc7665e847d09cc9ccadec546a2de05c40e8f4",
-                "reference": "16cc7665e847d09cc9ccadec546a2de05c40e8f4",
-                "shasum": ""
-            },
-            "require": {
-                "herrera-io/phar-update": "~2.0",
-                "php": ">=5.3.3",
-                "symfony/console": "~2.1"
-            },
-            "require-dev": {
-                "herrera-io/box": "~1.0",
-                "herrera-io/phpunit-test-case": "1.*",
-                "phpunit/phpunit": "3.7.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "KevinGH\\Amend": "src/lib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kevin Herrera",
-                    "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
-                }
-            ],
-            "description": "Integrates Phar Update to Symfony Console.",
-            "homepage": "http://github.com/box-project/amend",
-            "keywords": [
-                "console",
-                "phar",
-                "update"
-            ],
-            "time": "2014-11-05 15:29:01"
-        },
-        {
-            "name": "kherge/box",
-            "version": "2.7.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/box-project/box2.git",
-                "reference": "e50fa221d596582eef4793e214813d5f34e79c59"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/box-project/box2/zipball/e50fa221d596582eef4793e214813d5f34e79c59",
-                "reference": "e50fa221d596582eef4793e214813d5f34e79c59",
-                "shasum": ""
-            },
-            "require": {
-                "herrera-io/annotations": "~1.0",
-                "herrera-io/box": "~1.6",
-                "herrera-io/json": "~1.0",
-                "justinrainbow/json-schema": "~1.3",
-                "kherge/amend": "~3.0",
-                "phine/path": "~1.0",
-                "php": ">=5.3.3",
-                "phpseclib/phpseclib": "~2.0",
-                "symfony/console": "~2.1 || ~3.0",
-                "symfony/finder": "~2.1 || ~3.0",
-                "symfony/process": "~2.1 || ~3.0"
-            },
-            "require-dev": {
-                "herrera-io/phpunit-test-case": "1.*",
-                "mikey179/vfsstream": "1.1.0",
-                "phpunit/phpunit": "3.7.*"
-            },
-            "suggest": {
-                "ext-openssl": "To accelerate private key generation."
-            },
-            "bin": [
-                "bin/box"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "KevinGH\\Box": "src/lib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kevin Herrera",
-                    "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
-                }
-            ],
-            "description": "A tool to simplify building PHARs.",
-            "homepage": "http://box-project.github.io/box2/",
-            "keywords": [
-                "phar"
-            ],
-            "time": "2016-07-27 13:55:11"
         },
         {
             "name": "mikey179/vfsStream",
@@ -1813,84 +1696,78 @@
             "time": "2016-05-22 21:52:33"
         },
         {
-            "name": "phine/exception",
-            "version": "1.0.0",
+            "name": "myclabs/deep-copy",
+            "version": "1.5.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/kherge-abandoned/lib-exception.git",
-                "reference": "150c6b6090b2ebc53c60e87cb20c7f1287b7b68a"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kherge-abandoned/lib-exception/zipball/150c6b6090b2ebc53c60e87cb20c7f1287b7b68a",
-                "reference": "150c6b6090b2ebc53c60e87cb20c7f1287b7b68a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
+                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "league/phpunit-coverage-listener": "~1.0"
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Phine\\Exception": "src/lib"
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Kevin Herrera",
-                    "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
-                }
-            ],
-            "description": "A PHP library for improving the use of exceptions.",
-            "homepage": "https://github.com/phine/lib-exception",
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
-                "exception"
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
             ],
-            "time": "2013-08-27 17:43:25"
+            "time": "2016-09-16 13:37:59"
         },
         {
-            "name": "phine/path",
-            "version": "1.1.0",
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/box-project/box2-path.git",
-                "reference": "cbe1a5eb6cf22958394db2469af9b773508abddd"
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/box-project/box2-path/zipball/cbe1a5eb6cf22958394db2469af9b773508abddd",
-                "reference": "cbe1a5eb6cf22958394db2469af9b773508abddd",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
                 "shasum": ""
             },
             "require": {
-                "phine/exception": "~1.0",
-                "php": ">=5.3.3"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "league/phpunit-coverage-listener": "~1.0"
+                "phpunit/phpunit": "^4.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Phine\\Path": "src/lib"
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1899,53 +1776,49 @@
             ],
             "authors": [
                 {
-                    "name": "Kevin Herrera",
-                    "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io"
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
                 }
             ],
-            "description": "A PHP library for improving the use of file system paths.",
-            "homepage": "https://github.com/phine/lib-path",
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
             "keywords": [
-                "file",
-                "path",
-                "system"
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
             ],
-            "time": "2013-10-15 22:58:04"
+            "time": "2015-12-27 11:43:31"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
                         "src/"
                     ]
                 }
@@ -1957,47 +1830,45 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-09-30 07:12:33"
         },
         {
-            "name": "phpseclib/phpseclib",
-            "version": "2.0.2",
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "3d265f7c079f5b37d33475f996d7a383c5fc8aeb"
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/3d265f7c079f5b37d33475f996d7a383c5fc8aeb",
-                "reference": "3d265f7c079f5b37d33475f996d7a383c5fc8aeb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
-                "phing/phing": "~2.7",
-                "phpunit/phpunit": "~4.0",
-                "sami/sami": "~2.0",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "suggest": {
-                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
-                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
-                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
-                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
-                "files": [
-                    "phpseclib/bootstrap.php"
-                ],
                 "psr-4": {
-                    "phpseclib\\": "phpseclib/"
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2006,53 +1877,11 @@
             ],
             "authors": [
                 {
-                    "name": "Jim Wigginton",
-                    "email": "terrafrost@php.net",
-                    "role": "Lead Developer"
-                },
-                {
-                    "name": "Patrick Monnerat",
-                    "email": "pm@datasphere.ch",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Andreas Fischer",
-                    "email": "bantu@phpbb.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Hans-Jürgen Petrich",
-                    "email": "petrich@tronic-media.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Graham Campbell",
-                    "email": "graham@alt-three.com",
-                    "role": "Developer"
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
                 }
             ],
-            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
-            "homepage": "http://phpseclib.sourceforge.net",
-            "keywords": [
-                "BigInteger",
-                "aes",
-                "asn.1",
-                "asn1",
-                "blowfish",
-                "crypto",
-                "cryptography",
-                "encryption",
-                "rsa",
-                "security",
-                "sftp",
-                "signature",
-                "signing",
-                "ssh",
-                "twofish",
-                "x.509",
-                "x509"
-            ],
-            "time": "2016-05-13 01:15:21"
+            "time": "2016-06-10 07:14:17"
         },
         {
             "name": "phpspec/prophecy",
@@ -2118,39 +1947,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": "^5.6 || ^7.0",
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "~1.0|~2.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
+                "ext-xdebug": ">=2.4.0",
                 "ext-xmlwriter": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -2176,7 +2006,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2016-07-26 14:39:29"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2361,40 +2191,50 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.27",
+            "version": "5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
+                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
+                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "phpunit/php-code-coverage": "^4.0.1",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
+                "phpunit/phpunit-mock-objects": "^3.2",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
+                "sebastian/environment": "^1.3 || ^2.0",
                 "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
+                "sebastian/object-enumerator": "~1.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
             "suggest": {
+                "ext-xdebug": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -2403,7 +2243,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.6.x-dev"
                 }
             },
             "autoload": {
@@ -2429,30 +2269,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21 06:48:14"
+            "time": "2016-10-25 07:40:25"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
+                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -2460,7 +2303,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -2485,7 +2328,52 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2016-10-09 07:01:45"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13 06:45:14"
         },
         {
             "name": "sebastian/comparator",
@@ -2605,23 +2493,23 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.7",
+            "version": "1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8 || ^5.0"
             },
             "type": "library",
             "extra": {
@@ -2651,7 +2539,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2016-08-18 05:49:44"
         },
         {
             "name": "sebastian/exporter",
@@ -2772,6 +2660,52 @@
             "time": "2015-10-12 03:26:01"
         },
         {
+            "name": "sebastian/object-enumerator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-01-28 13:25:10"
+        },
+        {
             "name": "sebastian/recursion-context",
             "version": "1.0.2",
             "source": {
@@ -2825,20 +2759,70 @@
             "time": "2015-11-11 19:50:13"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -2857,32 +2841,38 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2016-02-04 12:56:52"
         },
         {
-            "name": "seld/jsonlint",
-            "version": "1.4.0",
+            "name": "webmozart/assert",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "66834d3e3566bb5798db7294619388786ae99394"
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/66834d3e3566bb5798db7294619388786ae99394",
-                "reference": "66834d3e3566bb5798db7294619388786ae99394",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3 || ^7.0"
+                "php": "^5.3.3|^7.0"
             },
-            "bin": [
-                "bin/jsonlint"
-            ],
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                    "Webmozart\\Assert\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2891,79 +2881,29 @@
             ],
             "authors": [
                 {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
-            "description": "JSON Linter",
+            "description": "Assertions to validate method input/output with nice error messages.",
             "keywords": [
-                "json",
-                "linter",
-                "parser",
-                "validator"
+                "assert",
+                "check",
+                "validate"
             ],
-            "time": "2015-11-21 02:21:41"
-        },
-        {
-            "name": "tedivm/jshrink",
-            "version": "v1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tedious/JShrink.git",
-                "reference": "688527a2e854d7935f24f24c7d5eb1b604742bf9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tedious/JShrink/zipball/688527a2e854d7935f24f24c7d5eb1b604742bf9",
-                "reference": "688527a2e854d7935f24f24c7d5eb1b604742bf9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "fabpot/php-cs-fixer": "0.4.0",
-                "phpunit/phpunit": "4.0.*",
-                "satooshi/php-coveralls": "dev-master"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "JShrink": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Robert Hafner",
-                    "email": "tedivm@tedivm.com"
-                }
-            ],
-            "description": "Javascript Minifier built in PHP",
-            "homepage": "http://github.com/tedious/JShrink",
-            "keywords": [
-                "javascript",
-                "minifier"
-            ],
-            "time": "2015-07-04 07:35:09"
+            "time": "2016-08-09 15:02:57"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "doctrine/migrations": 15
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.6"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.3.3"
+        "php": "5.6"
     }
 }

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -44,7 +44,7 @@ class ApplicationFactory
      */
     protected function getDefaultExtensions()
     {
-        return array(
+        return [
             new CliExtension(),
             new ConfigurationExtension(),
             new EventDispatcherExtension(),
@@ -59,7 +59,7 @@ class ApplicationFactory
             new PlatformExtension(),
             new ProcessExtension(),
             new ScriptsExtension(),
-        );
+        ];
     }
 
     /**

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -123,7 +123,7 @@ class Application extends BaseApplication
      * @param Exception $exception
      * @param OutputInterface $output
      */
-    public function renderException($exception, $output)
+    public function renderException(Exception $exception, OutputInterface $output)
     {
         parent::renderException($exception, $output);
 

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -88,10 +88,10 @@ class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        $workingDir = rtrim($input->getParameterOption(array('--working-dir', '-d')), '/');
+        $workingDir = rtrim($input->getParameterOption(['--working-dir', '-d']), '/');
         if ($workingDir === '') {
             // Fallback to the old --patch-path option
-            $workingDir = rtrim($input->getParameterOption(array('--patch-path')), '/');
+            $workingDir = rtrim($input->getParameterOption(['--patch-path']), '/');
             if ($workingDir === '') {
                 // Lastly fallback to the current directory
                 $workingDir = getcwd();
@@ -141,15 +141,15 @@ class Application extends BaseApplication
         }
 
         do {
-            $messages = array('', 'Error: '.get_class($exception), $exception->getMessage(), '', 'Exception trace:');
+            $messages = ['', 'Error: '.get_class($exception), $exception->getMessage(), '', 'Exception trace:'];
 
             $trace = $exception->getTrace();
-            array_unshift($trace, array(
+            array_unshift($trace, [
                 'function' => '',
                 'file' => $exception->getFile() !== null ? $exception->getFile() : 'n/a',
                 'line' => $exception->getLine() !== null ? $exception->getLine() : 'n/a',
-                'args' => array(),
-            ));
+                'args' => [],
+            ]);
 
             for ($i = 0, $count = count($trace); $i < $count; ++$i) {
                 $class = isset($trace[$i]['class']) ? $trace[$i]['class'] : '';

--- a/src/Configuration/ConfigurationLoader.php
+++ b/src/Configuration/ConfigurationLoader.php
@@ -110,7 +110,7 @@ class ConfigurationLoader
             throw new ConfigurationLoadingException('The configuration cannot be processed as the tree was not built');
         }
 
-        return $this->processor->process($this->tree, array($config));
+        return $this->processor->process($this->tree, [$config]);
     }
 
     /**
@@ -150,12 +150,12 @@ class ConfigurationLoader
     public function resolve($path)
     {
         $paths = array_filter(
-            array(
+            [
                 // NB: The package from packages should chosen first
                 $path.'/'.self::PACKAGE_CONFIG_NAME,
                 $path.'/'.self::CONFIG_NAME,
                 $path.'/'.self::DIST_CONFIG_NAME,
-            ),
+            ],
             'is_file'
         );
 

--- a/src/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -63,7 +63,7 @@ class EventDispatcherExtension extends ExtensionBase implements ExtensionInterfa
         $definition = $container->getDefinition(self::SERVICE_EVENT_DISPATCHER);
 
         foreach ($container->findTaggedServiceIds(self::TAG_SUBSCRIBER) as $id => $tags) {
-            $definition->addMethodCall('addSubscriber', array(new Reference($id)));
+            $definition->addMethodCall('addSubscriber', [new Reference($id)]);
         }
     }
 }

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -128,7 +128,7 @@ class Filesystem extends BaseFilesystem
      */
     public function findFiles($sourceDir, array $filters = null, $relative = true, $depth = null)
     {
-        $files = array();
+        $files = [];
 
         // Normalize dir
         $sourceDir = realpath($sourceDir);

--- a/src/Filesystem/Finder/FinderFactory.php
+++ b/src/Filesystem/Finder/FinderFactory.php
@@ -27,7 +27,7 @@ class FinderFactory
         }
 
         if ($filters !== null) {
-            $patterns = array();
+            $patterns = [];
             foreach ($filters as $filter) {
                 $patterns[] = $this->generatePattern($filter);
             }
@@ -85,6 +85,6 @@ class FinderFactory
 
         $pattern = '/'.str_replace('/', '\/', $pattern).'/';
 
-        return array($pattern, $negate);
+        return [$pattern, $negate];
     }
 }

--- a/src/Filesystem/ServiceContainer/FilesystemExtension.php
+++ b/src/Filesystem/ServiceContainer/FilesystemExtension.php
@@ -62,10 +62,10 @@ class FilesystemExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadFilesystem(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_FILESYSTEM, new Definition('Meteor\Filesystem\Filesystem', array(
+        $container->setDefinition(self::SERVICE_FILESYSTEM, new Definition('Meteor\Filesystem\Filesystem', [
             new Reference(self::SERVICE_FINDER_FACTORY),
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**

--- a/src/IO/ConsoleIO.php
+++ b/src/IO/ConsoleIO.php
@@ -248,7 +248,7 @@ class ConsoleIO implements IOInterface
      */
     private function block($message, $type = null, $style = null, $prefix = ' ', $padding = false)
     {
-        $messages = is_array($message) ? array_values($message) : array($message);
+        $messages = is_array($message) ? array_values($message) : [$message];
 
         $this->autoPrependBlock();
         $this->writeln($this->createBlock($messages, $type, $style, $prefix, $padding, true));
@@ -261,10 +261,10 @@ class ConsoleIO implements IOInterface
     public function title($message)
     {
         $this->autoPrependBlock();
-        $this->writeln(array(
+        $this->writeln([
             sprintf('<comment>%s</>', $message),
             sprintf('<comment>%s</>', str_repeat('=', Helper::strlenWithoutDecoration($this->output->getFormatter(), $message))),
-        ));
+        ]);
         $this->newLine();
     }
 
@@ -274,10 +274,10 @@ class ConsoleIO implements IOInterface
     public function section($message)
     {
         $this->autoPrependBlock();
-        $this->writeln(array(
+        $this->writeln([
             sprintf('<comment>%s</>', $message),
             sprintf('<comment>%s</>', str_repeat('-', Helper::strlenWithoutDecoration($this->output->getFormatter(), $message))),
-        ));
+        ]);
         $this->newLine();
     }
 
@@ -302,7 +302,7 @@ class ConsoleIO implements IOInterface
     {
         $this->autoPrependText();
 
-        $messages = is_array($message) ? array_values($message) : array($message);
+        $messages = is_array($message) ? array_values($message) : [$message];
         foreach ($messages as $message) {
             $this->writeln(sprintf(' %s', $message));
         }
@@ -313,7 +313,7 @@ class ConsoleIO implements IOInterface
      */
     public function debug($message)
     {
-        $messages = is_array($message) ? array_values($message) : array($message);
+        $messages = is_array($message) ? array_values($message) : [$message];
         $block = $this->createBlock($messages, null, null, '<fg=magenta;bg=default>-- </>');
 
         if ($this->isDebug()) {
@@ -477,14 +477,14 @@ class ConsoleIO implements IOInterface
         // Preserve the last 4 chars inserted (PHP_EOL on windows is two chars) in the history buffer
         return array_map(function ($value) {
             return substr($value, -4);
-        }, array_merge(array($this->bufferedOutput->fetch()), (array) $messages));
+        }, array_merge([$this->bufferedOutput->fetch()], (array) $messages));
     }
 
     private function createBlock($messages, $type = null, $style = null, $prefix = ' ', $padding = false, $escape = false)
     {
         $indentLength = 0;
         $prefixLength = Helper::strlenWithoutDecoration($this->output->getFormatter(), $prefix);
-        $lines = array();
+        $lines = [];
 
         if (null !== $type) {
             $type = sprintf('[%s] ', $type);

--- a/src/IO/NullIO.php
+++ b/src/IO/NullIO.php
@@ -44,7 +44,7 @@ class NullIO implements IOInterface
      */
     public function getOptions()
     {
-        return array();
+        return [];
     }
 
     /**

--- a/src/IO/ServiceContainer/IOExtension.php
+++ b/src/IO/ServiceContainer/IOExtension.php
@@ -45,11 +45,11 @@ class IOExtension extends ExtensionBase implements ExtensionInterface
      */
     public function load(ContainerBuilder $container, array $config)
     {
-        $container->setDefinition(self::SERVICE_IO, new Definition('Meteor\IO\ConsoleIO', array(
+        $container->setDefinition(self::SERVICE_IO, new Definition('Meteor\IO\ConsoleIO', [
             new Reference(CliExtension::SERVICE_INPUT),
             new Reference(CliExtension::SERVICE_OUTPUT),
             new Reference(LoggerExtension::SERVICE_LOGGER),
-        )));
+        ]));
     }
 
     /**

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -90,10 +90,10 @@ class Logger implements LoggerInterface
      */
     private function splitMessageLines($messages)
     {
-        $lines = array();
+        $lines = [];
 
         if (!is_array($messages)) {
-            $messages = array($messages);
+            $messages = [$messages];
         }
 
         foreach ($messages as $message) {

--- a/src/Migrations/Configuration/DoctrineConfiguration.php
+++ b/src/Migrations/Configuration/DoctrineConfiguration.php
@@ -21,7 +21,7 @@ abstract class DoctrineConfiguration extends Configuration
      *
      * @var Version[]
      */
-    protected $migrationVersions = array();
+    protected $migrationVersions = [];
 
     /**
      * Get the array of registered migration versions.
@@ -58,7 +58,7 @@ abstract class DoctrineConfiguration extends Configuration
      */
     public function getAvailableVersions()
     {
-        $availableVersions = array();
+        $availableVersions = [];
         foreach ($this->migrationVersions as $migration) {
             $availableVersions[] = $migration->getVersion();
         }
@@ -75,7 +75,7 @@ abstract class DoctrineConfiguration extends Configuration
 
         $where = null;
         if ($this->migrationVersions) {
-            $migratedVersions = array();
+            $migratedVersions = [];
             foreach ($this->migrationVersions as $migration) {
                 $migratedVersions[] = sprintf("'%s'", $migration->getVersion());
             }
@@ -138,12 +138,12 @@ abstract class DoctrineConfiguration extends Configuration
                 $classes = array_reverse(array_values($this->migrationVersions));
                 $allVersions = array_combine($allVersions, $classes);
             } else {
-                $allVersions = array();
+                $allVersions = [];
             }
         } else {
             $allVersions = $this->migrationVersions;
         }
-        $versions = array();
+        $versions = [];
         $migrated = $this->getMigratedVersions();
         foreach ($allVersions as $version) {
             if ($this->shouldMigrationBeExecuted($direction, $version, $to, $migrated)) {

--- a/src/Migrations/Configuration/FileConfiguration.php
+++ b/src/Migrations/Configuration/FileConfiguration.php
@@ -77,6 +77,6 @@ class FileConfiguration extends AbstractConfiguration implements JaduPathAwareCo
      */
     protected function createMigration($version, $class)
     {
-        return new FileMigrationVersion($this, $version, $class, $this->versionStorage);
+        return new FileMigrationVersion($this, $version, $class, null, $this->versionStorage);
     }
 }

--- a/src/Migrations/Connection/Configuration/Loader/ChainedConfigurationLoader.php
+++ b/src/Migrations/Connection/Configuration/Loader/ChainedConfigurationLoader.php
@@ -20,7 +20,7 @@ class ChainedConfigurationLoader implements ConfigurationLoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load($installDir, array $configuration = array())
+    public function load($installDir, array $configuration = [])
     {
         foreach ($this->loaders as $loader) {
             $configuration = array_merge(array_filter($loader->load($installDir, $configuration)), $configuration);

--- a/src/Migrations/Connection/Configuration/Loader/ConfigurationLoaderInterface.php
+++ b/src/Migrations/Connection/Configuration/Loader/ConfigurationLoaderInterface.php
@@ -8,5 +8,5 @@ interface ConfigurationLoaderInterface
      * @param string $installDir
      * @param array $configuration
      */
-    public function load($installDir, array $configuration = array());
+    public function load($installDir, array $configuration = []);
 }

--- a/src/Migrations/Connection/Configuration/Loader/InputOptionConfigurationLoader.php
+++ b/src/Migrations/Connection/Configuration/Loader/InputOptionConfigurationLoader.php
@@ -22,7 +22,7 @@ class InputOptionConfigurationLoader implements ConfigurationLoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load($installDir, array $configuration = array())
+    public function load($installDir, array $configuration = [])
     {
         if ($this->io->hasOption('db-name')) {
             $configuration['dbname'] = $this->io->getOption('db-name');

--- a/src/Migrations/Connection/Configuration/Loader/InputQuestionConfigurationLoader.php
+++ b/src/Migrations/Connection/Configuration/Loader/InputQuestionConfigurationLoader.php
@@ -22,7 +22,7 @@ class InputQuestionConfigurationLoader implements ConfigurationLoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load($installDir, array $configuration = array())
+    public function load($installDir, array $configuration = [])
     {
         if (!isset($configuration['dbname']) || empty($configuration['dbname'])) {
             $configuration['dbname'] = $this->io->ask('Enter the database name for migrations');

--- a/src/Migrations/Connection/Configuration/Loader/SystemConfigurationLoader.php
+++ b/src/Migrations/Connection/Configuration/Loader/SystemConfigurationLoader.php
@@ -9,7 +9,7 @@ class SystemConfigurationLoader implements ConfigurationLoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load($installDir, array $configuration = array())
+    public function load($installDir, array $configuration = [])
     {
         $path = $installDir.'/'.self::CONFIG_FILENAME;
 

--- a/src/Migrations/Connection/ConnectionFactory.php
+++ b/src/Migrations/Connection/ConnectionFactory.php
@@ -36,7 +36,7 @@ class ConnectionFactory
      */
     public function createFakeConnection()
     {
-        return new Connection(array(), new Driver());
+        return new Connection([], new Driver());
     }
 
     /**

--- a/src/Migrations/Generator/MigrationGenerator.php
+++ b/src/Migrations/Generator/MigrationGenerator.php
@@ -40,14 +40,14 @@ class Version<version> extends AbstractMigration
 PHP;
 
         $code = str_replace(
-            array(
+            [
                 '<namespace>',
                 '<version>',
-            ),
-            array(
+            ],
+            [
                 $namespace,
                 $version,
-            ),
+            ],
             $template
         );
 

--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -107,10 +107,10 @@ class Migrator
             $time += $version->getTime();
         }
 
-        $this->io->success(array(
+        $this->io->success([
             sprintf('%s %s migrations executed', $type, count($migrationsToExecute)),
             sprintf('Finished in %s', $time),
-        ));
+        ]);
 
         // NB: Migration version file will be updated when creating a backup rather than after running migrations
 

--- a/src/Migrations/Outputter/StatusOutputter.php
+++ b/src/Migrations/Outputter/StatusOutputter.php
@@ -41,8 +41,8 @@ class StatusOutputter
     {
         $configuration = $this->createConfiguration($type, $config, $patchDir, $installDir);
 
-        $formattedVersions = array();
-        foreach (array('prev', 'current', 'next', 'latest') as $alias) {
+        $formattedVersions = [];
+        foreach (['prev', 'current', 'next', 'latest'] as $alias) {
             $version = $configuration->resolveVersionAlias($alias);
             if ($version === null) {
                 if ($alias === 'next') {
@@ -63,21 +63,21 @@ class StatusOutputter
         $numExecutedUnavailableMigrations = count($executedUnavailableMigrations);
         $newMigrations = count(array_diff($availableMigrations, $executedMigrations));
 
-        $rows = array(
-            array('Version table name', $configuration->getMigrationsTableName()),
-            array('Migrations namespace', $configuration->getMigrationsNamespace()),
-            array('Migrations directory', $configuration->getMigrationsDirectory()),
-            array('Previous version', $formattedVersions['prev']),
-            array('Current version', $formattedVersions['current']),
-            array('Next version', $formattedVersions['next']),
-            array('Latest version', $formattedVersions['latest']),
-            array('Executed migrations', count($executedMigrations)),
-            array('Executed unavailable migrations', $numExecutedUnavailableMigrations > 0 ? '<error>'.$numExecutedUnavailableMigrations.'</error>' : 0),
-            array('Available migrations', count($availableMigrations)),
-            array('New migrations', $newMigrations > 0 ? '<question>'.$newMigrations.'</question>' : 0),
-        );
+        $rows = [
+            ['Version table name', $configuration->getMigrationsTableName()],
+            ['Migrations namespace', $configuration->getMigrationsNamespace()],
+            ['Migrations directory', $configuration->getMigrationsDirectory()],
+            ['Previous version', $formattedVersions['prev']],
+            ['Current version', $formattedVersions['current']],
+            ['Next version', $formattedVersions['next']],
+            ['Latest version', $formattedVersions['latest']],
+            ['Executed migrations', count($executedMigrations)],
+            ['Executed unavailable migrations', $numExecutedUnavailableMigrations > 0 ? '<error>'.$numExecutedUnavailableMigrations.'</error>' : 0],
+            ['Available migrations', count($availableMigrations)],
+            ['New migrations', $newMigrations > 0 ? '<question>'.$newMigrations.'</question>' : 0],
+        ];
 
-        $this->io->table(array(), $rows);
+        $this->io->table([], $rows);
 
         if ($showVersions) {
             $migrations = $configuration->getMigrations();

--- a/src/Migrations/ServiceContainer/MigrationsExtension.php
+++ b/src/Migrations/ServiceContainer/MigrationsExtension.php
@@ -65,7 +65,7 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     public function configParse(array $config)
     {
-        $extensionConfig = array();
+        $extensionConfig = [];
 
         if (isset($config['combined'])) {
             $extensionConfigKey = $this->getConfigKey();
@@ -138,21 +138,21 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadConnectionConfigurationLoader(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_CONNECTION_CONFIGURATION_LOADER_INPUT_OPTION, new Definition('Meteor\Migrations\Connection\Configuration\Loader\InputOptionConfigurationLoader', array(
+        $container->setDefinition(self::SERVICE_CONNECTION_CONFIGURATION_LOADER_INPUT_OPTION, new Definition('Meteor\Migrations\Connection\Configuration\Loader\InputOptionConfigurationLoader', [
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
         $container->setDefinition(self::SERVICE_CONNECTION_CONFIGURATION_LOADER_SYSTEM, new Definition('Meteor\Migrations\Connection\Configuration\Loader\SystemConfigurationLoader'));
-        $container->setDefinition(self::SERVICE_CONNECTION_CONFIGURATION_LOADER_INPUT_QUESTION, new Definition('Meteor\Migrations\Connection\Configuration\Loader\InputQuestionConfigurationLoader', array(
+        $container->setDefinition(self::SERVICE_CONNECTION_CONFIGURATION_LOADER_INPUT_QUESTION, new Definition('Meteor\Migrations\Connection\Configuration\Loader\InputQuestionConfigurationLoader', [
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
 
-        $container->setDefinition(self::SERVICE_CONNECTION_CONFIGURATION_LOADER, new Definition('Meteor\Migrations\Connection\Configuration\Loader\ChainedConfigurationLoader', array(
-            array(
+        $container->setDefinition(self::SERVICE_CONNECTION_CONFIGURATION_LOADER, new Definition('Meteor\Migrations\Connection\Configuration\Loader\ChainedConfigurationLoader', [
+            [
                 new Reference(self::SERVICE_CONNECTION_CONFIGURATION_LOADER_INPUT_OPTION),
                 new Reference(self::SERVICE_CONNECTION_CONFIGURATION_LOADER_SYSTEM),
                 new Reference(self::SERVICE_CONNECTION_CONFIGURATION_LOADER_INPUT_QUESTION),
-            ),
-        )));
+            ],
+        ]));
     }
 
     /**
@@ -160,9 +160,9 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadConnectionFactory(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_CONNECTION_FACTORY, new Definition('Meteor\Migrations\Connection\ConnectionFactory', array(
+        $container->setDefinition(self::SERVICE_CONNECTION_FACTORY, new Definition('Meteor\Migrations\Connection\ConnectionFactory', [
             new Reference(self::SERVICE_CONNECTION_CONFIGURATION_LOADER),
-        )));
+        ]));
     }
 
     /**
@@ -170,12 +170,12 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadConfigurationFactory(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_CONFIGURATION_FACTORY, new Definition('Meteor\Migrations\Configuration\ConfigurationFactory', array(
+        $container->setDefinition(self::SERVICE_CONFIGURATION_FACTORY, new Definition('Meteor\Migrations\Configuration\ConfigurationFactory', [
             new Reference(self::SERVICE_CONNECTION_FACTORY),
             new Reference(self::SERVICE_VERSION_FILE_MIGRATION_VERSION_STORAGE_FACTORY),
             new Reference(self::SERVICE_VERSION_FILE_MANAGER),
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**
@@ -183,7 +183,7 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadExecuteDatabaseMigrationCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\ExecuteMigrationCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\ExecuteMigrationCommand', [
             'migrations:execute',
             '%'.self::PARAMETER_MIGRATIONS.'%',
             new Reference(IOExtension::SERVICE_IO),
@@ -191,7 +191,7 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
             new Reference(self::SERVICE_MIGRATOR),
             new Reference(LoggerExtension::SERVICE_LOGGER),
             MigrationsConstants::TYPE_DATABASE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_EXECUTE_DATABASE_MIGRATION, $definition);
     }
@@ -201,7 +201,7 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadExecuteFileMigrationCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\ExecuteMigrationCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\ExecuteMigrationCommand', [
             'file-migrations:execute',
             '%'.self::PARAMETER_MIGRATIONS.'%',
             new Reference(IOExtension::SERVICE_IO),
@@ -209,7 +209,7 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
             new Reference(self::SERVICE_MIGRATOR),
             new Reference(LoggerExtension::SERVICE_LOGGER),
             MigrationsConstants::TYPE_FILE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_EXECUTE_FILE_MIGRATION, $definition);
     }
@@ -219,13 +219,13 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadGenerateDatabaseMigrationCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\GenerateMigrationCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\GenerateMigrationCommand', [
             'migrations:generate',
             '%'.Application::PARAMETER_CONFIG.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(self::SERVICE_MIGRATION_GENERATOR),
             MigrationsConstants::TYPE_DATABASE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_GENERATE_DATABASE_MIGRATION, $definition);
     }
@@ -235,13 +235,13 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadGenerateFileMigrationCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\GenerateMigrationCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\GenerateMigrationCommand', [
             'file-migrations:generate',
             '%'.Application::PARAMETER_CONFIG.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(self::SERVICE_MIGRATION_GENERATOR),
             MigrationsConstants::TYPE_FILE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_GENERATE_FILE_MIGRATION, $definition);
     }
@@ -259,10 +259,10 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadMigrator(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_MIGRATOR, new Definition('Meteor\Migrations\Migrator', array(
+        $container->setDefinition(self::SERVICE_MIGRATOR, new Definition('Meteor\Migrations\Migrator', [
             new Reference(self::SERVICE_CONFIGURATION_FACTORY),
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**
@@ -270,7 +270,7 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadMigrateDatabaseCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\MigrateCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\MigrateCommand', [
             'migrations:migrate',
             '%'.self::PARAMETER_MIGRATIONS.'%',
             new Reference(IOExtension::SERVICE_IO),
@@ -278,7 +278,7 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
             new Reference(self::SERVICE_MIGRATOR),
             new Reference(LoggerExtension::SERVICE_LOGGER),
             MigrationsConstants::TYPE_DATABASE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_MIGRATE_DATABASE, $definition);
     }
@@ -288,7 +288,7 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadMigrateFilesCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\MigrateCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\MigrateCommand', [
             'file-migrations:migrate',
             '%'.self::PARAMETER_MIGRATIONS.'%',
             new Reference(IOExtension::SERVICE_IO),
@@ -296,7 +296,7 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
             new Reference(self::SERVICE_MIGRATOR),
             new Reference(LoggerExtension::SERVICE_LOGGER),
             MigrationsConstants::TYPE_FILE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_MIGRATE_FILES, $definition);
     }
@@ -306,14 +306,14 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadDatabaseMigrationStatusCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\StatusCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\StatusCommand', [
             'migrations:status',
             '%'.self::PARAMETER_MIGRATIONS.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(PlatformExtension::SERVICE_PLATFORM),
             new Reference(self::SERVICE_STATUS_OUTPUTTER),
             MigrationsConstants::TYPE_DATABASE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_DATABASE_MIGRATION_STATUS, $definition);
     }
@@ -323,14 +323,14 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadFileMigrationStatusCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\StatusCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\StatusCommand', [
             'file-migrations:status',
             '%'.self::PARAMETER_MIGRATIONS.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(PlatformExtension::SERVICE_PLATFORM),
             new Reference(self::SERVICE_STATUS_OUTPUTTER),
             MigrationsConstants::TYPE_FILE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_FILE_MIGRATION_STATUS, $definition);
     }
@@ -340,10 +340,10 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadStatusOutputter(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_STATUS_OUTPUTTER, new Definition('Meteor\Migrations\Outputter\StatusOutputter', array(
+        $container->setDefinition(self::SERVICE_STATUS_OUTPUTTER, new Definition('Meteor\Migrations\Outputter\StatusOutputter', [
             new Reference(self::SERVICE_CONFIGURATION_FACTORY),
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**
@@ -351,14 +351,14 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadDatabaseMigrationVersionCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\VersionCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\VersionCommand', [
             'migrations:version',
             '%'.self::PARAMETER_MIGRATIONS.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(PlatformExtension::SERVICE_PLATFORM),
             new Reference(self::SERVICE_VERSION_MANAGER),
             MigrationsConstants::TYPE_DATABASE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_DATABASE_MIGRATION_VERSION, $definition);
     }
@@ -368,14 +368,14 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadFileMigrationVersionCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Migrations\Cli\Command\VersionCommand', array(
+        $definition = new Definition('Meteor\Migrations\Cli\Command\VersionCommand', [
             'file-migrations:version',
             '%'.self::PARAMETER_MIGRATIONS.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(PlatformExtension::SERVICE_PLATFORM),
             new Reference(self::SERVICE_VERSION_MANAGER),
             MigrationsConstants::TYPE_FILE,
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_FILE_MIGRATION_VERSION, $definition);
     }
@@ -398,9 +398,9 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
     {
         $container->setDefinition(
             self::SERVICE_VERSION_FILE_MIGRATION_VERSION_STORAGE_FACTORY,
-            new Definition('Meteor\Migrations\Version\FileMigrationVersionStorageFactory', array(
+            new Definition('Meteor\Migrations\Version\FileMigrationVersionStorageFactory', [
                 new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
-            ))
+            ])
         );
     }
 
@@ -411,10 +411,10 @@ class MigrationsExtension extends ExtensionBase implements ExtensionInterface
     {
         $container->setDefinition(
             self::SERVICE_VERSION_MANAGER,
-            new Definition('Meteor\Migrations\Version\VersionManager', array(
+            new Definition('Meteor\Migrations\Version\VersionManager', [
                 new Reference(self::SERVICE_CONFIGURATION_FACTORY),
                 new Reference(IOExtension::SERVICE_IO),
-            ))
+            ])
         );
     }
 

--- a/src/Migrations/Version/FileMigrationVersion.php
+++ b/src/Migrations/Version/FileMigrationVersion.php
@@ -3,6 +3,7 @@
 namespace Meteor\Migrations\Version;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Provider\SchemaDiffProviderInterface;
 use Doctrine\DBAL\Migrations\Version;
 
 class FileMigrationVersion extends Version
@@ -16,11 +17,12 @@ class FileMigrationVersion extends Version
      * @param Configuration $configuration
      * @param string $version
      * @param string $class
+     * @param SchemaDiffProviderInterface $schemaProvider
      * @param FileMigrationVersionStorage $versionStorage
      */
-    public function __construct(Configuration $configuration, $version, $class, FileMigrationVersionStorage $versionStorage)
+    public function __construct(Configuration $configuration, $version, $class, SchemaDiffProviderInterface $schemaProvider = null, FileMigrationVersionStorage $versionStorage = null)
     {
-        parent::__construct($configuration, $version, $class);
+        parent::__construct($configuration, $version, $class, $schemaProvider);
 
         $this->versionStorage = $versionStorage;
     }

--- a/src/Migrations/Version/FileMigrationVersionStorage.php
+++ b/src/Migrations/Version/FileMigrationVersionStorage.php
@@ -132,7 +132,7 @@ class FileMigrationVersionStorage
                 $this->versions = explode("\n", file_get_contents($this->file));
                 $this->normaliseVersions();
             } else {
-                $this->versions = array();
+                $this->versions = [];
             }
         }
     }

--- a/src/Package/Combined/CombinedPackageDependencyChecker.php
+++ b/src/Package/Combined/CombinedPackageDependencyChecker.php
@@ -23,14 +23,14 @@ class CombinedPackageDependencyChecker
         }
 
         // Normalise package names and create a keyed array of configs
-        $combinedPackages = array();
+        $combinedPackages = [];
         if (isset($config['combined'])) {
             foreach ($config['combined'] as $combinedConfig) {
                 $combinedPackages[strtolower($combinedConfig['name'])] = $combinedConfig;
             }
         }
 
-        $problems = array();
+        $problems = [];
         foreach ($requirements as $requirement) {
             if (!isset($combinedPackages[strtolower($requirement->getPackageName())])) {
                 $problems[] = new CombinedPackageProblem($requirement, CombinedPackageProblem::REASON_MISSING);
@@ -64,7 +64,7 @@ class CombinedPackageDependencyChecker
      */
     private function resolveRequirements(array $config)
     {
-        $requirements = array();
+        $requirements = [];
 
         if (isset($config['package']) && isset($config['package']['combine'])) {
             foreach ($config['package']['combine'] as $packageName => $version) {

--- a/src/Package/Combined/CombinedPackageResolver.php
+++ b/src/Package/Combined/CombinedPackageResolver.php
@@ -66,7 +66,7 @@ class CombinedPackageResolver
             $config = $this->packageCombiner->combine($packagePath, $outputDir, $tempDir, $config, $excludeVendor);
         }
 
-        $requiredPackages = isset($config['package']['combine']) ? $config['package']['combine'] : array();
+        $requiredPackages = isset($config['package']['combine']) ? $config['package']['combine'] : [];
 
         if (!empty($requiredPackages) && $this->packageProvider !== null) {
             foreach ($requiredPackages as $packageName => $version) {

--- a/src/Package/Combined/Exception/CombinedPackageDependenciesException.php
+++ b/src/Package/Combined/Exception/CombinedPackageDependenciesException.php
@@ -10,7 +10,7 @@ class CombinedPackageDependenciesException extends Exception
     /**
      * @var CombinedPackageProblem[]
      */
-    private $problems = array();
+    private $problems = [];
 
     /**
      * @return CombinedPackageProblem[]

--- a/src/Package/Combined/PackageCombiner.php
+++ b/src/Package/Combined/PackageCombiner.php
@@ -85,7 +85,7 @@ class PackageCombiner
         $this->io->text('Copying files into the working directory:');
 
         // Include everything in the patch
-        $include = array('/**');
+        $include = ['/**'];
 
         // Except vendor if excluded
         if ($excludeVendor) {
@@ -102,7 +102,7 @@ class PackageCombiner
         $packageConfig = $this->migrationsCopier->copy($extractedDir, $tempDir, $packageConfig);
 
         if (!isset($config['combined'])) {
-            $config['combined'] = array();
+            $config['combined'] = [];
         }
 
         if (isset($packageConfig['combined'])) {

--- a/src/Package/Composer/ComposerDependencyChecker.php
+++ b/src/Package/Composer/ComposerDependencyChecker.php
@@ -19,7 +19,7 @@ class ComposerDependencyChecker
         $jsonPath = $workingDir.'/composer.json';
 
         if (!file_exists($jsonPath)) {
-            return array();
+            return [];
         }
 
         $json = json_decode(file_get_contents($jsonPath), true);
@@ -27,7 +27,7 @@ class ComposerDependencyChecker
             throw ComposerDependenciesException::forInvalidJsonFile($jsonPath);
         }
 
-        $requirements = array();
+        $requirements = [];
         if (isset($json['require'])) {
             foreach ($json['require'] as $packageName => $versionConstraint) {
                 if ($packageName === 'php') {
@@ -51,7 +51,7 @@ class ComposerDependencyChecker
      */
     public function check($workingDir, array $config)
     {
-        $requirements = array();
+        $requirements = [];
         if (isset($config['combined'])) {
             foreach ($config['combined'] as $combinedConfig) {
                 if (isset($combinedConfig['package']) && isset($combinedConfig['package']['composer'])) {
@@ -76,14 +76,14 @@ class ComposerDependencyChecker
             throw ComposerDependenciesException::forInvalidLockFile($lockPath);
         }
 
-        $packages = array();
+        $packages = [];
         if (isset($lock['packages'])) {
             foreach ($lock['packages'] as $package) {
                 $packages[strtolower($package['name'])] = $package['version'];
             }
         }
 
-        $problems = array();
+        $problems = [];
         foreach ($requirements as $requirement) {
             if (!isset($packages[strtolower($requirement->getPackageName())])) {
                 $problems[] = new ComposerProblem($requirement, ComposerProblem::REASON_MISSING);
@@ -108,10 +108,10 @@ class ComposerDependencyChecker
     public function addRequirements(array $requirements, array $config)
     {
         if (!isset($config['package'])) {
-            $config['package'] = array();
+            $config['package'] = [];
         }
 
-        $config['package']['composer'] = array();
+        $config['package']['composer'] = [];
 
         foreach ($requirements as $requirement) {
             if ($requirement instanceof ComposerRequirement) {

--- a/src/Package/Composer/Exception/ComposerDependenciesException.php
+++ b/src/Package/Composer/Exception/ComposerDependenciesException.php
@@ -10,7 +10,7 @@ class ComposerDependenciesException extends Exception
     /**
      * @var ComposerProblem[]
      */
-    private $problems = array();
+    private $problems = [];
 
     /**
      * @return ComposerProblem[]

--- a/src/Package/PackageCreator.php
+++ b/src/Package/PackageCreator.php
@@ -190,7 +190,7 @@ class PackageCreator
     {
         $this->io->error('The package could not be created as required Meteor packages were missing');
 
-        $problems = array();
+        $problems = [];
         foreach ($exception->getProblems() as $problem) {
             $problems[] = (string) $problem;
         }
@@ -212,7 +212,7 @@ class PackageCreator
     {
         $this->io->error('The package could not be created as required Composer packages were missing');
 
-        $problems = array();
+        $problems = [];
         foreach ($exception->getProblems() as $problem) {
             $problems[] = (string) $problem;
         }

--- a/src/Package/PackageExtractor.php
+++ b/src/Package/PackageExtractor.php
@@ -43,7 +43,7 @@ class PackageExtractor
         $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
 
         foreach ($iterator as $file) {
-            if (in_array($file->getFilename(), array(ConfigurationLoader::CONFIG_NAME, ConfigurationLoader::PACKAGE_CONFIG_NAME), true)) {
+            if (in_array($file->getFilename(), [ConfigurationLoader::CONFIG_NAME, ConfigurationLoader::PACKAGE_CONFIG_NAME], true)) {
                 return $file->getPath();
             }
         }

--- a/src/Package/Provider/GoogleDrive/ServiceContainer/GoogleDrivePackageProviderExtension.php
+++ b/src/Package/Provider/GoogleDrive/ServiceContainer/GoogleDrivePackageProviderExtension.php
@@ -49,10 +49,10 @@ class GoogleDrivePackageProviderExtension extends ExtensionBase implements Exten
                 ->end()
                 ->arrayNode('folders')
                     ->normalizeKeys(false)
-                    ->defaultValue(array(
+                    ->defaultValue([
                         'jadu/cms' => '0B3tlQeNsllCKY2tzbFpUUkI2OGM',
                         'jadu/xfp' => '0B2h2-RgE2WidOHRhZVNUbUc1Z0E',
-                    ))
+                    ])
                     ->prototype('scalar')->end()
                 ->end()
             ->end()
@@ -80,12 +80,12 @@ class GoogleDrivePackageProviderExtension extends ExtensionBase implements Exten
         $container->setParameter(self::PARAMETER_BINARY, $config['binary']);
         $container->setParameter(self::PARAMETER_FOLDERS, $config['folders']);
 
-        $definition = new Definition('Meteor\Package\Provider\GoogleDrive\GoogleDrivePackageProvider', array(
+        $definition = new Definition('Meteor\Package\Provider\GoogleDrive\GoogleDrivePackageProvider', [
             new Reference(ProcessExtension::SERVICE_PROCESS_RUNNER),
             new Reference(IOExtension::SERVICE_IO),
             '%'.self::PARAMETER_BINARY.'%',
             '%'.self::PARAMETER_FOLDERS.'%',
-        ));
+        ]);
         $container->setDefinition(PackageExtension::SERVICE_PROVIDER_PREFIX.'.'.self::PROVIDER_NAME, $definition);
     }
 

--- a/src/Package/ServiceContainer/PackageExtension.php
+++ b/src/Package/ServiceContainer/PackageExtension.php
@@ -113,13 +113,13 @@ class PackageExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadCombinedPackageCombiner(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_COMBINED_PACKAGE_COMBINER, new Definition('Meteor\Package\Combined\PackageCombiner', array(
+        $container->setDefinition(self::SERVICE_COMBINED_PACKAGE_COMBINER, new Definition('Meteor\Package\Combined\PackageCombiner', [
             new Reference(ConfigurationExtension::SERVICE_LOADER),
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
             new Reference(self::SERVICE_PACKAGE_EXTRACTOR),
             new Reference(self::SERVICE_MIGRATIONS_COPIER),
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**
@@ -127,13 +127,13 @@ class PackageExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadCombinedPackageResolver(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_COMBINED_PACKAGE_RESOLVER, new Definition('Meteor\Package\Combined\CombinedPackageResolver', array(
+        $container->setDefinition(self::SERVICE_COMBINED_PACKAGE_RESOLVER, new Definition('Meteor\Package\Combined\CombinedPackageResolver', [
             new Reference(self::SERVICE_COMBINED_PACKAGE_COMBINER),
             new Reference(self::SERVICE_COMBINED_PACKAGE_DEPENDENCY_CHECKER),
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
             new Reference(IOExtension::SERVICE_IO),
             new Reference(self::SERVICE_PROVIDER, ContainerInterface::NULL_ON_INVALID_REFERENCE),
-        )));
+        ]));
     }
 
     /**
@@ -149,10 +149,10 @@ class PackageExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadMigrationsCopier(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_MIGRATIONS_COPIER, new Definition('Meteor\Package\Migrations\MigrationsCopier', array(
+        $container->setDefinition(self::SERVICE_MIGRATIONS_COPIER, new Definition('Meteor\Package\Migrations\MigrationsCopier', [
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**
@@ -160,10 +160,10 @@ class PackageExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadPackageArchiver(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_PACKAGE_ARCHIVER, new Definition('Meteor\Package\PackageArchiver', array(
+        $container->setDefinition(self::SERVICE_PACKAGE_ARCHIVER, new Definition('Meteor\Package\PackageArchiver', [
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**
@@ -179,7 +179,7 @@ class PackageExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadPackageCreator(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_PACKAGE_CREATOR, new Definition('Meteor\Package\PackageCreator', array(
+        $container->setDefinition(self::SERVICE_PACKAGE_CREATOR, new Definition('Meteor\Package\PackageCreator', [
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
             new Reference(self::SERVICE_PACKAGE_ARCHIVER),
             new Reference(self::SERVICE_PACKAGE_NAME_RESOLVER),
@@ -188,7 +188,7 @@ class PackageExtension extends ExtensionBase implements ExtensionInterface
             new Reference(self::SERVICE_COMPOSER_DEPENDENCY_CHECKER),
             new Reference(ConfigurationExtension::SERVICE_WRITER),
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**
@@ -196,12 +196,12 @@ class PackageExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadPackageCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Package\Cli\Command\PackageCommand', array(
+        $definition = new Definition('Meteor\Package\Cli\Command\PackageCommand', [
             null,
             '%'.Application::PARAMETER_CONFIG.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(self::SERVICE_PACKAGE_CREATOR),
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_PACKAGE, $definition);
     }

--- a/src/Patch/Backup/BackupFinder.php
+++ b/src/Patch/Backup/BackupFinder.php
@@ -39,11 +39,11 @@ class BackupFinder
      */
     public function find($installDir, array $config)
     {
-        $backups = array();
+        $backups = [];
         $backupsDir = $installDir.'/backups';
         $packageNames = $this->getPackageNames($config);
 
-        $backupDirs = array();
+        $backupDirs = [];
         foreach (new DirectoryIterator($backupsDir) as $file) {
             if (!$file->isDot() && $file->isDir() && preg_match('/^\d{14}$/', $file->getFilename())) {
                 $backupDirs[] = $file->getPathname();
@@ -83,7 +83,7 @@ class BackupFinder
      */
     private function getPackageNames(array $config)
     {
-        $packageNames = array($config['name']);
+        $packageNames = [$config['name']];
 
         if (isset($config['combined'])) {
             foreach ($config['combined'] as $combinedConfig) {

--- a/src/Patch/Cli/Command/ApplyCommand.php
+++ b/src/Patch/Cli/Command/ApplyCommand.php
@@ -125,7 +125,7 @@ class ApplyCommand extends AbstractPatchCommand
      */
     protected function checkPhpConstraint(array $config)
     {
-        $versions = array();
+        $versions = [];
 
         if (isset($config['package']['php'])) {
             $versions[$config['name']] = $config['package']['php'];

--- a/src/Patch/Cli/Command/RollbackCommand.php
+++ b/src/Patch/Cli/Command/RollbackCommand.php
@@ -155,28 +155,28 @@ class RollbackCommand extends AbstractPatchCommand
             return 1;
         }
 
-        $backupChoices = array();
-        $backupRows = array();
+        $backupChoices = [];
+        $backupRows = [];
         foreach ($backups as $index => $backup) {
             $backupChoices[] = $index;
 
-            $backupVersions = array();
+            $backupVersions = [];
             foreach ($backup->getVersions() as $version) {
                 $backupVersions[] = sprintf('<comment>%s</>: %s', $version->getPackageName(), $version->getNewVersion());
             }
 
-            $backupRows[] = array(
+            $backupRows[] = [
                 $index,
                 $backup->getDate()->format('c'),
                 implode($backupVersions, ', '),
-            );
+            ];
         }
 
-        $this->io->table(array(
+        $this->io->table([
             'Choice',
             'Date',
             'Versions',
-        ), $backupRows);
+        ], $backupRows);
 
         // NB: The first backup will be the most recent
         $backupChoice = (int) $this->io->ask('Please select a backup to rollback to:', 0);
@@ -215,7 +215,7 @@ class RollbackCommand extends AbstractPatchCommand
             $this->io->text('Intermediate backups to be removed:');
             $this->io->listing($intermediateBackupDates);
         } else {
-            $intermediateBackupDirs = array();
+            $intermediateBackupDirs = [];
         }
 
         $tasks = $this->strategy->rollback($backup->getPath(), $workingDir, $installDir, $intermediateBackupDirs, $this->io->getOptions());

--- a/src/Patch/ServiceContainer/PatchExtension.php
+++ b/src/Patch/ServiceContainer/PatchExtension.php
@@ -68,12 +68,12 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     public function getEventNames()
     {
-        return array(
+        return [
             PatchEvents::PRE_APPLY,
             PatchEvents::POST_APPLY,
             PatchEvents::PRE_ROLLBACK,
             PatchEvents::POST_ROLLBACK,
-        );
+        ];
     }
 
     /**
@@ -134,10 +134,10 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadBackupFinder(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_BACKUP_FINDER, new Definition('Meteor\Patch\Backup\BackupFinder', array(
+        $container->setDefinition(self::SERVICE_BACKUP_FINDER, new Definition('Meteor\Patch\Backup\BackupFinder', [
             new Reference(self::SERVICE_VERSION_COMPARER),
             new Reference(ConfigurationExtension::SERVICE_LOADER),
-        )));
+        ]));
     }
 
     /**
@@ -153,14 +153,14 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadBackupFilesTaskHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\BackupFilesHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\BackupFilesHandler', [
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
             new Reference(ConfigurationExtension::SERVICE_LOADER),
             new Reference(IOExtension::SERVICE_IO),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\BackupFiles',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_BACKUP_FILES_HANDLER, $definition);
     }
@@ -170,12 +170,12 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadCheckDatabaseConnectionTaskHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\CheckDatabaseConnectionHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\CheckDatabaseConnectionHandler', [
             new Reference(MigrationsExtension::SERVICE_CONNECTION_FACTORY),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\CheckDatabaseConnection',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_CHECK_DATABASE_CONNECTION_HANDLER, $definition);
     }
@@ -185,14 +185,14 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadCheckDiskSpaceHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\CheckDiskSpaceHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\CheckDiskSpaceHandler', [
             new Reference(self::SERVICE_BACKUP_FINDER),
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
             new Reference(IOExtension::SERVICE_IO),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\CheckDiskSpace',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_CHECK_DISK_SPACE_HANDLER, $definition);
     }
@@ -202,12 +202,12 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadCheckModuleCmsDependencyTaskHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\CheckModuleCmsDependencyHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\CheckModuleCmsDependencyHandler', [
             new Reference(IOExtension::SERVICE_IO),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\CheckModuleCmsDependency',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_CHECK_MODULE_CMS_DEPENDENCY_HANDLER, $definition);
     }
@@ -217,13 +217,13 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadCheckVersionTaskHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\CheckVersionHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\CheckVersionHandler', [
             new Reference(IOExtension::SERVICE_IO),
             new Reference(self::SERVICE_VERSION_COMPARER),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\CheckVersion',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_CHECK_VERSION_HANDLER, $definition);
     }
@@ -233,12 +233,12 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadCheckWritePermissionTaskHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\CheckWritePermissionHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\CheckWritePermissionHandler', [
             new Reference(IOExtension::SERVICE_IO),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\CheckWritePermission',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_CHECK_WRITE_PERMISSION_HANDLER, $definition);
     }
@@ -248,14 +248,14 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadCopyFilesHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\CopyFilesHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\CopyFilesHandler', [
             new Reference(IOExtension::SERVICE_IO),
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
             new Reference(PermissionsExtension::SERVICE_PERMISSION_SETTER),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\CopyFiles',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_COPY_FILES_HANDLER, $definition);
     }
@@ -265,13 +265,13 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadDeleteBackupHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\DeleteBackupHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\DeleteBackupHandler', [
             new Reference(IOExtension::SERVICE_IO),
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\DeleteBackup',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_DELETE_BACKUP_HANDLER, $definition);
     }
@@ -281,13 +281,13 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadDisplayVersionInfoTaskHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\DisplayVersionInfoHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\DisplayVersionInfoHandler', [
             new Reference(IOExtension::SERVICE_IO),
             new Reference(self::SERVICE_VERSION_COMPARER),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\DisplayVersionInfo',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_DISPLAY_VERSION_INFO_HANDLER, $definition);
     }
@@ -297,14 +297,14 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadMigrateDownTaskHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\MigrateDownHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\MigrateDownHandler', [
             new Reference(MigrationsExtension::SERVICE_MIGRATOR),
             new Reference(MigrationsExtension::SERVICE_VERSION_FILE_MANAGER),
             new Reference(IOExtension::SERVICE_IO),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\MigrateDown',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_MIGRATE_DOWN_HANDLER, $definition);
     }
@@ -314,13 +314,13 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadMigrateUpTaskHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\MigrateUpHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\MigrateUpHandler', [
             new Reference(MigrationsExtension::SERVICE_MIGRATOR),
             new Reference(IOExtension::SERVICE_IO),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\MigrateUp',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_MIGRATE_UP_HANDLER, $definition);
     }
@@ -330,14 +330,14 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadUpdateMigrationVersionFilesTaskHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Task\UpdateMigrationVersionFilesHandler', array(
+        $definition = new Definition('Meteor\Patch\Task\UpdateMigrationVersionFilesHandler', [
             new Reference(MigrationsExtension::SERVICE_CONFIGURATION_FACTORY),
             new Reference(MigrationsExtension::SERVICE_VERSION_FILE_MANAGER),
             new Reference(IOExtension::SERVICE_IO),
-        ));
-        $definition->addTag(self::TAG_TASK_HANDLER, array(
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
             'task' => 'Meteor\Patch\Task\UpdateMigrationVersionFiles',
-        ));
+        ]);
 
         $container->setDefinition(self::SERVICE_TASK_UPDATE_MIGRATION_VERSION_FILES_HANDLER, $definition);
     }
@@ -347,7 +347,7 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadApplyCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Cli\Command\ApplyCommand', array(
+        $definition = new Definition('Meteor\Patch\Cli\Command\ApplyCommand', [
             null,
             '%'.Application::PARAMETER_CONFIG.'%',
             new Reference(IOExtension::SERVICE_IO),
@@ -358,7 +358,7 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
             new Reference(EventDispatcherExtension::SERVICE_EVENT_DISPATCHER),
             new Reference(ScriptsExtension::SERVICE_SCRIPT_RUNNER),
             new Reference(LoggerExtension::SERVICE_LOGGER),
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_APPLY, $definition);
     }
@@ -370,13 +370,13 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
     {
         $this->loadLocker($container);
 
-        $definition = new Definition('Meteor\Patch\Cli\Command\ClearLockCommand', array(
+        $definition = new Definition('Meteor\Patch\Cli\Command\ClearLockCommand', [
             null,
             '%'.Application::PARAMETER_CONFIG.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(PlatformExtension::SERVICE_PLATFORM),
             new Reference(self::SERVICE_LOCKER),
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_CLEAR_LOCK, $definition);
     }
@@ -394,7 +394,7 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadRollbackCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Cli\Command\RollbackCommand', array(
+        $definition = new Definition('Meteor\Patch\Cli\Command\RollbackCommand', [
             null,
             '%'.Application::PARAMETER_CONFIG.'%',
             new Reference(IOExtension::SERVICE_IO),
@@ -407,7 +407,7 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
             new Reference(EventDispatcherExtension::SERVICE_EVENT_DISPATCHER),
             new Reference(ScriptsExtension::SERVICE_SCRIPT_RUNNER),
             new Reference(LoggerExtension::SERVICE_LOGGER),
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_ROLLBACK, $definition);
     }
@@ -417,13 +417,13 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
      */
     private function loadVersionInfoCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Patch\Cli\Command\VersionInfoCommand', array(
+        $definition = new Definition('Meteor\Patch\Cli\Command\VersionInfoCommand', [
             null,
             '%'.Application::PARAMETER_CONFIG.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(PlatformExtension::SERVICE_PLATFORM),
             new Reference(self::SERVICE_TASK_BUS),
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_VERSION_INFO, $definition);
     }
@@ -456,10 +456,10 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
                     throw new Exception(sprintf('The %s tag must always have a task attribute', self::TAG_TASK_HANDLER));
                 }
 
-                $container->getDefinition(self::SERVICE_TASK_BUS)->addMethodCall('registerHandler', array(
+                $container->getDefinition(self::SERVICE_TASK_BUS)->addMethodCall('registerHandler', [
                     $attributes['task'],
                     new Reference($id),
-                ));
+                ]);
             }
         }
     }

--- a/src/Patch/Strategy/Overwrite/OverwritePatchStrategy.php
+++ b/src/Patch/Strategy/Overwrite/OverwritePatchStrategy.php
@@ -27,7 +27,7 @@ class OverwritePatchStrategy implements PatchStrategyInterface
      */
     public function apply($patchDir, $installDir, array $options)
     {
-        $tasks = array();
+        $tasks = [];
         $patchFilesDir = $patchDir.'/'.PackageConstants::PATCH_DIR;
         $backupDir = $installDir.'/backups/'.date('YmdHis');
 
@@ -78,7 +78,7 @@ class OverwritePatchStrategy implements PatchStrategyInterface
      */
     public function rollback($backupDir, $patchDir, $installDir, array $intermediateBackupDirs, array $options)
     {
-        $tasks = array();
+        $tasks = [];
         $backupFilesDir = $backupDir.'/'.PackageConstants::PATCH_DIR;
 
         $tasks[] = new CheckWritePermission($installDir);

--- a/src/Patch/Task/CheckVersion.php
+++ b/src/Patch/Task/CheckVersion.php
@@ -34,7 +34,7 @@ class CheckVersion
         $this->workingDir = $workingDir;
         $this->installDir = $installDir;
 
-        if (!in_array($operator, array(self::GREATER_THAN_OR_EQUAL, self::LESS_THAN_OR_EQUAL), true)) {
+        if (!in_array($operator, [self::GREATER_THAN_OR_EQUAL, self::LESS_THAN_OR_EQUAL], true)) {
             throw new InvalidArgumentException('Invalid operator');
         }
 

--- a/src/Patch/Task/DisplayVersionInfoHandler.php
+++ b/src/Patch/Task/DisplayVersionInfoHandler.php
@@ -44,23 +44,23 @@ class DisplayVersionInfoHandler
                 $status = '<fg=yellow>No change</>';
             }
 
-            $rows[] = array(
+            $rows[] = [
                 $version->getPackageName(),
                 $version->getFileName(),
                 $version->getCurrentVersion(),
                 $version->getNewVersion(),
                 $status,
-            );
+            ];
         }
 
         if (isset($rows)) {
-            $this->io->table(array(
+            $this->io->table([
                 'Name',
                 'Version file',
                 'Current version',
                 'Patch version',
                 'Status',
-            ), $rows);
+            ], $rows);
         }
     }
 }

--- a/src/Patch/Task/TaskBus.php
+++ b/src/Patch/Task/TaskBus.php
@@ -9,7 +9,7 @@ class TaskBus implements TaskBusInterface
     /**
      * @var array
      */
-    private $handlers = array();
+    private $handlers = [];
 
     /**
      * @param string $className

--- a/src/Patch/Task/UpdateMigrationVersionFilesHandler.php
+++ b/src/Patch/Task/UpdateMigrationVersionFilesHandler.php
@@ -44,7 +44,7 @@ class UpdateMigrationVersionFilesHandler
      */
     public function handle(UpdateMigrationVersionFiles $task, array $config)
     {
-        $migrationConfigs = array();
+        $migrationConfigs = [];
         if (isset($config['migrations'])) {
             $migrationConfigs[$config['name']] = $config['migrations'];
         }

--- a/src/Patch/Version/VersionComparer.php
+++ b/src/Patch/Version/VersionComparer.php
@@ -44,7 +44,7 @@ class VersionComparer
      */
     public function comparePackage($patchDir, $installDir, array $config)
     {
-        $versions = array();
+        $versions = [];
 
         if (isset($config['package']['version'])) {
             try {

--- a/src/Permissions/PermissionLoader.php
+++ b/src/Permissions/PermissionLoader.php
@@ -17,7 +17,7 @@ class PermissionLoader
      */
     public function load($installDir)
     {
-        $permissions = array();
+        $permissions = [];
 
         // Load all permissions files in the path
         $finder = new Finder();

--- a/src/Permissions/PermissionSetter.php
+++ b/src/Permissions/PermissionSetter.php
@@ -47,7 +47,7 @@ class PermissionSetter
     {
         $targetDir = rtrim($targetDir, '/');
 
-        $permissionErrors = array();
+        $permissionErrors = [];
         foreach ($files as $file) {
             try {
                 $this->platform->setDefaultPermission($targetDir, $file);
@@ -73,7 +73,7 @@ class PermissionSetter
 
         $this->io->text(sprintf('Setting file permissions in <info>%s</>', $targetDir));
 
-        $permissionErrors = array();
+        $permissionErrors = [];
         $permissions = $this->permissionLoader->load($targetDir);
         if (empty($permissions)) {
             return;
@@ -119,20 +119,20 @@ class PermissionSetter
             $targetPath = $targetDir.'/'.$pattern;
             if (!file_exists($targetPath)) {
                 // File does not exist
-                return array();
+                return [];
             }
 
-            return array($targetPath);
+            return [$targetPath];
         }
 
         $basePath = $baseDir.'/'.$pattern;
         $baseDirname = dirname($basePath);
         if (!is_dir($baseDirname)) {
             // Directory does not exist
-            return array();
+            return [];
         }
 
-        $paths = array();
+        $paths = [];
         $finder = new Finder();
         $finder->in($baseDirname);
         $finder->ignoreVCS(true);

--- a/src/Permissions/ServiceContainer/PermissionsExtension.php
+++ b/src/Permissions/ServiceContainer/PermissionsExtension.php
@@ -67,11 +67,11 @@ class PermissionsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadPermissionSetter(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_PERMISSION_SETTER, new Definition('Meteor\Permissions\PermissionSetter', array(
+        $container->setDefinition(self::SERVICE_PERMISSION_SETTER, new Definition('Meteor\Permissions\PermissionSetter', [
             new Reference(PlatformExtension::SERVICE_PLATFORM),
             new Reference(self::SERVICE_PERMISSION_LOADER),
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**
@@ -79,13 +79,13 @@ class PermissionsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadResetPermissionsCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Permissions\Cli\Command\ResetPermissionsCommand', array(
+        $definition = new Definition('Meteor\Permissions\Cli\Command\ResetPermissionsCommand', [
             null,
             '%'.Application::PARAMETER_CONFIG.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(PlatformExtension::SERVICE_PLATFORM),
             new Reference(self::SERVICE_PERMISSION_SETTER),
-        ));
+        ]);
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_RESET_PERMISSIONS, $definition);
     }

--- a/src/Platform/ServiceContainer/PlatformExtension.php
+++ b/src/Platform/ServiceContainer/PlatformExtension.php
@@ -57,9 +57,9 @@ class PlatformExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadWindowsPlatform(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_PLATFORM_WINDOWS, new Definition('Meteor\Platform\Windows\WindowsPlatform', array(
+        $container->setDefinition(self::SERVICE_PLATFORM_WINDOWS, new Definition('Meteor\Platform\Windows\WindowsPlatform', [
             new Reference(ProcessExtension::SERVICE_PROCESS_RUNNER),
-        )));
+        ]));
     }
 
     /**
@@ -77,10 +77,10 @@ class PlatformExtension extends ExtensionBase implements ExtensionInterface
     {
         $this->loadUnixPlatformInstallConfigLoader($container);
 
-        $definition = new Definition('Meteor\Platform\Unix\UnixPlatform', array(
+        $definition = new Definition('Meteor\Platform\Unix\UnixPlatform', [
             new Reference(self::SERVICE_UNIX_INSTALL_CONFIG_LOADER),
             new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
-        ));
+        ]);
         $container->setDefinition(self::SERVICE_PLATFORM_UNIX, $definition);
     }
 

--- a/src/Process/ServiceContainer/ProcessExtension.php
+++ b/src/Process/ServiceContainer/ProcessExtension.php
@@ -52,9 +52,9 @@ class ProcessExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadProcessRunner(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_PROCESS_RUNNER, new Definition('Meteor\Process\ProcessRunner', array(
+        $container->setDefinition(self::SERVICE_PROCESS_RUNNER, new Definition('Meteor\Process\ProcessRunner', [
             new Reference(IOExtension::SERVICE_IO),
-        )));
+        ]));
     }
 
     /**

--- a/src/Scripts/EventListener/ScriptEventListener.php
+++ b/src/Scripts/EventListener/ScriptEventListener.php
@@ -22,9 +22,10 @@ class ScriptEventListener
 
     /**
      * @param Event $event
+     * @param string $eventName
      */
-    public function handleEvent(Event $event)
+    public function handleEvent(Event $event, $eventName)
     {
-        $this->scriptRunner->run($event->getName());
+        $this->scriptRunner->run($eventName);
     }
 }

--- a/src/Scripts/ServiceContainer/ScriptsExtension.php
+++ b/src/Scripts/ServiceContainer/ScriptsExtension.php
@@ -28,17 +28,17 @@ class ScriptsExtension extends ExtensionBase implements ExtensionInterface
     /**
      * @var array
      */
-    private $eventNames = array();
+    private $eventNames = [];
 
     /**
      * @var array
      */
-    private $scripts = array();
+    private $scripts = [];
 
     /**
      * @var array
      */
-    private $referenced = array();
+    private $referenced = [];
 
     /**
      * Returns the extension config key.
@@ -68,7 +68,7 @@ class ScriptsExtension extends ExtensionBase implements ExtensionInterface
      */
     public function configParse(array $config)
     {
-        $extensionConfig = array();
+        $extensionConfig = [];
         $extensionConfig[] = parent::configParse($config);
 
         if (isset($config['combined'])) {
@@ -102,7 +102,7 @@ class ScriptsExtension extends ExtensionBase implements ExtensionInterface
                 ->beforeNormalization()
                     ->ifString()
                     ->then(function ($value) {
-                        return array($value);
+                        return [$value];
                     })
                 ->end()
                 ->prototype('scalar')->end()
@@ -122,7 +122,7 @@ class ScriptsExtension extends ExtensionBase implements ExtensionInterface
         $this->scripts = $scripts;
 
         // NB: Resetting so loading multiple script configs does not cause circular references
-        $this->referenced = array();
+        $this->referenced = [];
 
         foreach (array_keys($scripts) as $name) {
             // NB: Exceptions will be caught and used as the error message
@@ -174,9 +174,9 @@ class ScriptsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadEventListener(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_EVENT_LISTENER, new Definition('Meteor\Scripts\EventListener\ScriptEventListener', array(
+        $container->setDefinition(self::SERVICE_EVENT_LISTENER, new Definition('Meteor\Scripts\EventListener\ScriptEventListener', [
             new Reference(self::SERVICE_SCRIPT_RUNNER),
-        )));
+        ]));
     }
 
     /**
@@ -184,21 +184,21 @@ class ScriptsExtension extends ExtensionBase implements ExtensionInterface
      */
     private function loadScriptRunner(ContainerBuilder $container)
     {
-        $container->setDefinition(self::SERVICE_SCRIPT_RUNNER, new Definition('Meteor\Scripts\ScriptRunner', array(
+        $container->setDefinition(self::SERVICE_SCRIPT_RUNNER, new Definition('Meteor\Scripts\ScriptRunner', [
             new Reference(ProcessExtension::SERVICE_PROCESS_RUNNER),
             new Reference(IOExtension::SERVICE_IO),
             '%'.self::PARAMETER_SCRIPTS.'%',
-        )));
+        ]));
     }
 
     private function loadRunCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Meteor\Scripts\Cli\Command\RunCommand', array(
+        $definition = new Definition('Meteor\Scripts\Cli\Command\RunCommand', [
             null,
             '%'.Application::PARAMETER_CONFIG.'%',
             new Reference(IOExtension::SERVICE_IO),
             new Reference(self::SERVICE_SCRIPT_RUNNER),
-        ));
+        ]);
 
         $definition->addTag(CliExtension::TAG_COMMAND);
         $container->setDefinition(self::SERVICE_COMMAND_RUN, $definition);
@@ -212,7 +212,7 @@ class ScriptsExtension extends ExtensionBase implements ExtensionInterface
         $definition = $container->getDefinition(EventDispatcherExtension::SERVICE_EVENT_DISPATCHER);
 
         foreach ($this->eventNames as $eventName) {
-            $definition->addMethodCall('addListener', array($eventName, array(new Reference(self::SERVICE_EVENT_LISTENER), 'handleEvent')));
+            $definition->addMethodCall('addListener', [$eventName, [new Reference(self::SERVICE_EVENT_LISTENER), 'handleEvent']]);
         }
     }
 }

--- a/src/ServiceContainer/ExtensionBase.php
+++ b/src/ServiceContainer/ExtensionBase.php
@@ -9,7 +9,7 @@ abstract class ExtensionBase
      */
     public function configParse(array $config)
     {
-        $extensionConfig = array();
+        $extensionConfig = [];
         $extensionConfigKey = $this->getConfigKey();
 
         if (isset($config[$extensionConfigKey])) {

--- a/src/ServiceContainer/ExtensionManager.php
+++ b/src/ServiceContainer/ExtensionManager.php
@@ -9,7 +9,7 @@ class ExtensionManager
     /**
      * @var ExtensionInterface[]
      */
-    private $extensions = array();
+    private $extensions = [];
 
     /**
      * @param ExtensionInterface[] $extensions

--- a/tests/ApplicationFactoryTest.php
+++ b/tests/ApplicationFactoryTest.php
@@ -22,12 +22,12 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCanRunPatchApplyCommand()
     {
         // Attempt to run the patch:apply command
-        $input = new ArrayInput(array(
+        $input = new ArrayInput([
             'command' => 'patch:apply',
             '--working-dir' => __DIR__,
             // NB: Intentionally omitted the --install-dir option
             //  so that the command does not properly execute during tests.
-        ));
+        ]);
 
         $input->setInteractive(false);
 

--- a/tests/BackwardsCompatibility/Config/InstallConfigLoaderTest.php
+++ b/tests/BackwardsCompatibility/Config/InstallConfigLoaderTest.php
@@ -70,9 +70,9 @@ FINISHED_INSTALL_PHASES="check_config_templates"
 PHPWRAPPER_FILE="php-wrapper"
 CONF;
 
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'install.conf' => $installConf,
-        ));
+        ]);
 
         $config = $this->loader->load(vfsStream::url('root'));
 
@@ -100,9 +100,9 @@ CONF;
      */
     public function testLoadThrowsExceptionWhenFileCannotBeParsed()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'install.conf' => '!',
-        ));
+        ]);
 
         $this->loader->load(vfsStream::url('root'));
     }

--- a/tests/BackwardsCompatibility/Config/InstallConfigTest.php
+++ b/tests/BackwardsCompatibility/Config/InstallConfigTest.php
@@ -6,20 +6,20 @@ class InstallConfigTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetWebUserFallsBackToApacheUserWhenNotSuexec()
     {
-        $config = new InstallConfig(array(
+        $config = new InstallConfig([
             'SUEXEC' => 'no',
             'APACHE_USER' => 'apache',
-        ));
+        ]);
 
         $this->assertSame('apache', $config->getWebUser());
     }
 
     public function testGetWebGroupFallsBackToApacheGroupWhenNotSuexec()
     {
-        $config = new InstallConfig(array(
+        $config = new InstallConfig([
             'SUEXEC' => 'no',
             'APACHE_GROUP' => 'apache',
-        ));
+        ]);
 
         $this->assertSame('apache', $config->getWebGroup());
     }
@@ -29,20 +29,20 @@ class InstallConfigTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsSuexec($value, $expectedResult)
     {
-        $config = new InstallConfig(array(
+        $config = new InstallConfig([
             'SUEXEC' => $value,
-        ));
+        ]);
 
         $this->assertSame($expectedResult, $config->isSuexec());
     }
 
     public function suexecValueProvider()
     {
-        return array(
-            array('', false),
-            array('n', false),
-            array('y', false),
-            array('yes', true),
-        );
+        return [
+            ['', false],
+            ['n', false],
+            ['y', false],
+            ['yes', true],
+        ];
     }
 }

--- a/tests/Cli/Command/CommandTestCase.php
+++ b/tests/Cli/Command/CommandTestCase.php
@@ -14,7 +14,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $extensionManager = new ExtensionManager(array());
+        $extensionManager = new ExtensionManager([]);
         $configurationLoader = new ConfigurationLoader($extensionManager);
 
         $this->command = $this->createCommand();

--- a/tests/Cli/Command/CommandTester.php
+++ b/tests/Cli/Command/CommandTester.php
@@ -39,9 +39,9 @@ class CommandTester
      *
      * @return int The command exit code
      */
-    public function execute(array $input, array $options = array())
+    public function execute(array $input, array $options = [])
     {
-        $input = array_merge(array('command' => $this->command->getName()), $input);
+        $input = array_merge(['command' => $this->command->getName()], $input);
 
         $this->input = new ArrayInput($input);
         $this->input->setInteractive(false);

--- a/tests/Cli/ServiceContainer/CliExtensionTest.php
+++ b/tests/Cli/ServiceContainer/CliExtensionTest.php
@@ -8,7 +8,7 @@ class CliExtensionTest extends ExtensionTestCase
 {
     public function testHasCommandServiceIdsParameter()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         $this->assertTrue($container->hasParameter(CliExtension::PARAMETER_COMMAND_SERVICE_IDS));
     }

--- a/tests/Configuration/ConfigurationLoaderTest.php
+++ b/tests/Configuration/ConfigurationLoaderTest.php
@@ -16,9 +16,9 @@ class ConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->extensionManager = Mockery::mock('Meteor\ServiceContainer\ExtensionManager', array(
-            'getExtensions' => array(),
-        ));
+        $this->extensionManager = Mockery::mock('Meteor\ServiceContainer\ExtensionManager', [
+            'getExtensions' => [],
+        ]);
         $this->treeBuilder = new TreeBuilder();
         $this->processor = new Processor();
         $this->configurationLoader = new ConfigurationLoader($this->extensionManager, $this->treeBuilder, $this->processor);
@@ -26,35 +26,35 @@ class ConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildTreeConfiguresExtensions()
     {
-        $extension = Mockery::mock('Meteor\ServiceContainer\ExtensionInterface', array(
+        $extension = Mockery::mock('Meteor\ServiceContainer\ExtensionInterface', [
             'getConfigKey' => 'test',
-        ));
+        ]);
 
         // NB: Twice due to building the combined package tree as well
         $extension->shouldReceive('configure')
             ->twice();
 
-        $this->configurationLoader->buildTree(array($extension));
+        $this->configurationLoader->buildTree([$extension]);
     }
 
     public function testAllowsNameSection()
     {
-        $this->configurationLoader->buildTree(array());
+        $this->configurationLoader->buildTree([]);
 
-        $config = $this->configurationLoader->process(array(
+        $config = $this->configurationLoader->process([
             'name' => 'jadu/xfp',
-        ));
+        ]);
 
-        $this->assertArraySubset(array(
+        $this->assertArraySubset([
             'name' => 'jadu/xfp',
-        ), $config);
+        ], $config);
     }
 
     public function testGeneratesAUniqueNameIfNotProvided()
     {
-        $this->configurationLoader->buildTree(array());
+        $this->configurationLoader->buildTree([]);
 
-        $config = $this->configurationLoader->process(array());
+        $config = $this->configurationLoader->process([]);
 
         $this->assertArrayHasKey('name', $config);
         $this->assertNotEmpty($config['name']);
@@ -62,19 +62,19 @@ class ConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowsExtensionsSection()
     {
-        $this->configurationLoader->buildTree(array());
+        $this->configurationLoader->buildTree([]);
 
-        $config = $this->configurationLoader->process(array(
-            'extensions' => array(
+        $config = $this->configurationLoader->process([
+            'extensions' => [
                 'Meteor\Test\ServiceContainer\TestExtension',
-            ),
-        ));
+            ],
+        ]);
 
-        $this->assertArraySubset(array(
-            'extensions' => array(
+        $this->assertArraySubset([
+            'extensions' => [
                 'Meteor\Test\ServiceContainer\TestExtension',
-            ),
-        ), $config);
+            ],
+        ], $config);
     }
 
     public function testParseReturnsConfigAsArray()
@@ -88,18 +88,18 @@ class ConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
 }
 JSON;
 
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'meteor.json' => $json,
-        ));
+        ]);
 
         $config = $this->configurationLoader->parse(vfsStream::url('root/meteor.json'));
 
-        $this->assertSame(array(
+        $this->assertSame([
             'name' => 'jadu/xfp',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'JaduMigrationsXFP',
-            ),
-        ), $config);
+            ],
+        ], $config);
     }
 
     /**
@@ -117,9 +117,9 @@ JSON;
      */
     public function testParseThrowsExceptionWhenJsonCannotBeParsed()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'meteor.json' => '!!!',
-        ));
+        ]);
 
         $this->configurationLoader->parse(vfsStream::url('root/meteor.json'));
     }
@@ -132,18 +132,18 @@ JSON;
 }
 JSON;
 
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'meteor.json' => $json,
-        ));
+        ]);
 
-        $this->configurationLoader->buildTree(array());
+        $this->configurationLoader->buildTree([]);
         $config = $this->configurationLoader->load(vfsStream::url('root'));
 
-        $this->assertSame(array(
+        $this->assertSame([
             'name' => 'jadu/xfp',
-            'extensions' => array(),
-            'combined' => array(),
-        ), $config);
+            'extensions' => [],
+            'combined' => [],
+        ], $config);
     }
 
     public function testLoadCombined()
@@ -159,23 +159,23 @@ JSON;
 }
 JSON;
 
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'meteor.json' => $json,
-        ));
+        ]);
 
-        $this->configurationLoader->buildTree(array());
+        $this->configurationLoader->buildTree([]);
         $config = $this->configurationLoader->load(vfsStream::url('root'));
 
-        $this->assertSame(array(
+        $this->assertSame([
             'name' => 'jadu/xfp',
-            'combined' => array(
-                array(
+            'combined' => [
+                [
                     'name' => 'jadu/cms',
-                    'extensions' => array(),
-                ),
-            ),
-            'extensions' => array(),
-        ), $config);
+                    'extensions' => [],
+                ],
+            ],
+            'extensions' => [],
+        ], $config);
     }
 
     public function testLoadIgnoresUnrecognisedOptionsWhenNotStrict()
@@ -187,18 +187,18 @@ JSON;
 }
 JSON;
 
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'meteor.json' => $json,
-        ));
+        ]);
 
-        $this->configurationLoader->buildTree(array());
+        $this->configurationLoader->buildTree([]);
         $config = $this->configurationLoader->load(vfsStream::url('root'), false);
 
-        $this->assertSame(array(
+        $this->assertSame([
             'name' => 'jadu/xfp',
-            'extensions' => array(),
-            'combined' => array(),
-        ), $config);
+            'extensions' => [],
+            'combined' => [],
+        ], $config);
     }
 
     /**
@@ -206,6 +206,6 @@ JSON;
      */
     public function testCannotProcessBeforeTreeIsBuild()
     {
-        $this->configurationLoader->process(array());
+        $this->configurationLoader->process([]);
     }
 }

--- a/tests/Configuration/ConfigurationWriterTest.php
+++ b/tests/Configuration/ConfigurationWriterTest.php
@@ -18,14 +18,14 @@ class ConfigurationWriterTest extends \PHPUnit_Framework_TestCase
     public function testWritesJsonFileToGivenPath()
     {
         $path = vfsStream::url('root/meteor.package.json');
-        $config = array(
+        $config = [
             'name' => 'jadu/xfp',
-            'package' => array(
-                'files' => array(
+            'package' => [
+                'files' => [
                     '/**',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $expectedJson = <<<JSON
 {
@@ -47,11 +47,11 @@ JSON;
     public function testRemovesEmptyValues()
     {
         $path = vfsStream::url('root/meteor.package.json');
-        $config = array(
+        $config = [
             'name' => 'jadu/xfp',
-            'package' => array(),
+            'package' => [],
             'migrations' => null,
-        );
+        ];
 
         $expectedJson = <<<JSON
 {

--- a/tests/Configuration/ServiceContainer/ConfigurationExtensionTest.php
+++ b/tests/Configuration/ServiceContainer/ConfigurationExtensionTest.php
@@ -8,7 +8,7 @@ class ConfigurationExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,8 +17,8 @@ class ConfigurationExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             ConfigurationExtension::SERVICE_WRITER,
-        );
+        ];
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -53,7 +53,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateTempDirectoryReturnsRandomDirectoryNames()
     {
-        $paths = array();
+        $paths = [];
         for ($i = 0; $i < 100; ++$i) {
             $paths[] = $this->filesystem->createTempDirectory();
         }
@@ -82,16 +82,16 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testFindFilesWithRelativePaths()
     {
-        vfsStream::setup('root', null, array(
-            'public_html' => array(
+        vfsStream::setup('root', null, [
+            'public_html' => [
                 'index.html' => '',
-            ),
-            'var' => array(
-                'config' => array(
+            ],
+            'var' => [
+                'config' => [
                     'system.xml' => '',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
         $sourceDir = vfsStream::url('root');
 
@@ -104,27 +104,27 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
         $files = $this->filesystem->findFiles($sourceDir);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'public_html',
             'public_html/index.html',
             'var',
             'var/config',
             'var/config/system.xml',
-        ), $files);
+        ], $files);
     }
 
     public function testFindFilesWithRelativePathsWhenSourceDirInputDiffersToRealPath()
     {
-        vfsStream::setup('root', null, array(
-            'public_html' => array(
+        vfsStream::setup('root', null, [
+            'public_html' => [
                 'index.html' => '',
-            ),
-            'var' => array(
-                'config' => array(
+            ],
+            'var' => [
+                'config' => [
                     'system.xml' => '',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
         // The fake realpath function will lowercase the path so it will differ
         $sourceDir = vfsStream::url('root');
@@ -138,27 +138,27 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
         $files = $this->filesystem->findFiles(strtoupper($sourceDir));
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'public_html',
             'public_html/index.html',
             'var',
             'var/config',
             'var/config/system.xml',
-        ), $files);
+        ], $files);
     }
 
     public function testFindFilesWithAbsolutePaths()
     {
-        vfsStream::setup('root', null, array(
-            'public_html' => array(
+        vfsStream::setup('root', null, [
+            'public_html' => [
                 'index.html' => '',
-            ),
-            'var' => array(
-                'config' => array(
+            ],
+            'var' => [
+                'config' => [
                     'system.xml' => '',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
         $sourceDir = vfsStream::url('root');
 
@@ -171,13 +171,13 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
         $files = $this->filesystem->findFiles($sourceDir, null, false);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'vfs://root/public_html',
             'vfs://root/public_html/index.html',
             'vfs://root/var',
             'vfs://root/var/config',
             'vfs://root/var/config/system.xml',
-        ), $files);
+        ], $files);
     }
 
     public function testFindFilesWithFilters()
@@ -188,33 +188,33 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $finder->in($sourceDir);
 
         $this->finderFactory->shouldReceive('create')
-            ->with($sourceDir, array('/**'), null)
+            ->with($sourceDir, ['/**'], null)
             ->andReturn($finder)
             ->once();
 
-        $this->filesystem->findFiles($sourceDir, array('/**'));
+        $this->filesystem->findFiles($sourceDir, ['/**']);
     }
 
     public function testFindNewFiles()
     {
-        vfsStream::setup('root', null, array(
-            'base' => array(
-                'public_html' => array(
+        vfsStream::setup('root', null, [
+            'base' => [
+                'public_html' => [
                     'index.html' => '',
-                ),
-                'var' => array(
-                    'config' => array(
+                ],
+                'var' => [
+                    'config' => [
                         'system.xml' => '',
-                    ),
-                ),
-            ),
-            'target' => array(
-                'public_html' => array(
+                    ],
+                ],
+            ],
+            'target' => [
+                'public_html' => [
                     'index.html' => '',
-                ),
-                'var' => array(),
-            ),
-        ));
+                ],
+                'var' => [],
+            ],
+        ]);
 
         $baseDir = vfsStream::url('root/base');
         $targetDir = vfsStream::url('root/target');
@@ -228,26 +228,26 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
         $files = $this->filesystem->findNewFiles($baseDir, $targetDir);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'var/config',
             'var/config/system.xml',
-        ), $files);
+        ], $files);
     }
 
     public function testCopyDirectory()
     {
-        vfsStream::setup('root', null, array(
-            'source' => array(
+        vfsStream::setup('root', null, [
+            'source' => [
                 'index.html' => '',
-                'var' => array(
-                    'config' => array(
+                'var' => [
+                    'config' => [
                         'system.xml' => '',
-                    ),
-                    'cache' => array(),
-                ),
-            ),
-            'target' => array(),
-        ));
+                    ],
+                    'cache' => [],
+                ],
+            ],
+            'target' => [],
+        ]);
 
         $this->assertTrue($this->filesystem->copyDirectory(vfsStream::url('root/source'), vfsStream::url('root/target')));
 
@@ -258,32 +258,32 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testCopyDirectoryReturnsFalseWhenEmpty()
     {
-        vfsStream::setup('root', null, array(
-            'source' => array(),
-            'target' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'source' => [],
+            'target' => [],
+        ]);
 
         $this->assertFalse($this->filesystem->copyDirectory(vfsStream::url('root/source'), vfsStream::url('root/target')));
     }
 
     public function testCopyDirectoryWithFiltersOnlyCopiesFilteredFiles()
     {
-        vfsStream::setup('root', null, array(
-            'source' => array(
+        vfsStream::setup('root', null, [
+            'source' => [
                 'index.html' => '',
-            ),
-            'target' => array(),
-        ));
+            ],
+            'target' => [],
+        ]);
 
         $finder = new Finder();
         $finder->in(vfsStream::url('root/source'));
 
         $this->finderFactory->shouldReceive('create')
-            ->with(vfsStream::url('root/source'), array('/**'), null)
+            ->with(vfsStream::url('root/source'), ['/**'], null)
             ->andReturn($finder)
             ->once();
 
-        $this->filesystem->copyDirectory(vfsStream::url('root/source'), vfsStream::url('root/target'), array('/**'));
+        $this->filesystem->copyDirectory(vfsStream::url('root/source'), vfsStream::url('root/target'), ['/**']);
     }
 }
 

--- a/tests/Filesystem/Finder/FinderFactoryTest.php
+++ b/tests/Filesystem/Finder/FinderFactoryTest.php
@@ -22,7 +22,7 @@ class FinderFactoryTest extends \PHPUnit_Framework_TestCase
 
         $finder = $this->finderFactory->create(vfsStream::url('root'), $filters);
 
-        $foundFiles = array();
+        $foundFiles = [];
         foreach ($finder as $file) {
             $foundFiles[] = preg_replace('/^'.preg_quote(vfsStream::url('root').'/', '/').'/', '', $file->getPathname());
         }
@@ -32,155 +32,155 @@ class FinderFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function filterProvider()
     {
-        return array(
-            array(
-                array(
+        return [
+            [
+                [
                     'index.html' => '',
                     'XFP_VERSION' => '',
-                ),
-                array(
+                ],
+                [
                     '**',
-                ),
-                array(
+                ],
+                [
                     'index.html',
                     'XFP_VERSION',
-                ),
-            ),
-            array(
-                array(
+                ],
+            ],
+            [
+                [
                     'index.html' => '',
-                ),
-                array(
+                ],
+                [
                     'index.html',
-                ),
-                array(
+                ],
+                [
                     'index.html',
-                ),
-            ),
-            array(
-                array(
+                ],
+            ],
+            [
+                [
                     'index.html' => '',
-                ),
-                array(
+                ],
+                [
                     '!index.html',
-                ),
-                array(
-                ),
-            ),
-            array(
-                array(
+                ],
+                [
+                ],
+            ],
+            [
+                [
                     'XFP_VERSION' => '',
-                ),
-                array(
+                ],
+                [
                     '*VERSION',
-                ),
-                array(
+                ],
+                [
                     'XFP_VERSION',
-                ),
-            ),
-            array(
-                array(
-                    'var' => array(
+                ],
+            ],
+            [
+                [
+                    'var' => [
                         'XFP_VERSION' => '',
-                    ),
+                    ],
                     'VERSION' => '',
-                ),
-                array(
+                ],
+                [
                     '*VERSION',
-                ),
-                array(
+                ],
+                [
                     'var/XFP_VERSION',
                     'VERSION',
-                ),
-            ),
-            array(
-                array(
-                    'var' => array(
+                ],
+            ],
+            [
+                [
+                    'var' => [
                         'XFP_VERSION' => '1.3.2',
-                    ),
+                    ],
                     'VERSION' => '',
-                ),
-                array(
+                ],
+                [
                     '/*VERSION',
-                ),
-                array(
+                ],
+                [
                     'VERSION',
-                ),
-            ),
-            array(
-                array(
-                    'var' => array(
+                ],
+            ],
+            [
+                [
+                    'var' => [
                         'XFP_VERSION' => '1.3.2',
-                    ),
+                    ],
                     'VERSION' => '',
-                ),
-                array(
+                ],
+                [
                     '**VERSION',
                     '!/*VERSION',
-                ),
-                array(
+                ],
+                [
                     'var/XFP_VERSION',
-                ),
-            ),
-            array(
-                array(
-                    'backups' => array(
-                        '20160701102030' => array(
+                ],
+            ],
+            [
+                [
+                    'backups' => [
+                        '20160701102030' => [
                             'CORE_MIGRATION_NUMBER' => '2',
-                        ),
-                    ),
+                        ],
+                    ],
                     'CORE_MIGRATION_NUMBER' => '1',
-                ),
-                array(
+                ],
+                [
                     '/*_MIGRATION_NUMBER',
-                ),
-                array(
+                ],
+                [
                     'CORE_MIGRATION_NUMBER',
-                ),
-            ),
-            array(
-                array(
-                    'backups' => array(
-                        '20160701102030' => array(
+                ],
+            ],
+            [
+                [
+                    'backups' => [
+                        '20160701102030' => [
                             'CORE_MIGRATION_NUMBER' => '2',
-                        ),
-                    ),
+                        ],
+                    ],
                     'CORE_MIGRATION_NUMBER' => '1',
-                ),
-                array(
+                ],
+                [
                     '*_MIGRATION_NUMBER',
-                ),
-                array(
+                ],
+                [
                     'backups/20160701102030/CORE_MIGRATION_NUMBER',
                     'CORE_MIGRATION_NUMBER',
-                ),
-            ),
-            array(
-                array(
-                    'public_html' => array(
+                ],
+            ],
+            [
+                [
+                    'public_html' => [
                         '.htaccess' => '',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     '/public_html/**',
-                ),
-                array(
+                ],
+                [
                     'public_html/.htaccess',
-                ),
-            ),
-            array(
-                array(
-                    'public_html' => array(
+                ],
+            ],
+            [
+                [
+                    'public_html' => [
                         '.htaccess' => '',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     '.htaccess',
-                ),
-                array(
+                ],
+                [
                     'public_html/.htaccess',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 }

--- a/tests/Filesystem/ServiceContainer/FilesystemExtensionTest.php
+++ b/tests/Filesystem/ServiceContainer/FilesystemExtensionTest.php
@@ -8,7 +8,7 @@ class FilesystemExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,9 +17,9 @@ class FilesystemExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             FilesystemExtension::SERVICE_FILESYSTEM,
             FilesystemExtension::SERVICE_FINDER_FACTORY,
-        );
+        ];
     }
 }

--- a/tests/IO/ConsoleIOTest.php
+++ b/tests/IO/ConsoleIOTest.php
@@ -12,7 +12,7 @@ class ConsoleIOTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->input = new ArrayInput(array());
+        $this->input = new ArrayInput([]);
         $this->input->setInteractive(true);
 
         $this->output = new StreamOutput(fopen('php://memory', 'w', false));
@@ -52,11 +52,11 @@ class ConsoleIOTest extends \PHPUnit_Framework_TestCase
 
     public function testListing()
     {
-        $this->io->listing(array(
+        $this->io->listing([
             'Item 1',
             'Item 2',
             'Item 3',
-        ));
+        ]);
 
         $this->assertOutputEquals('listing');
     }
@@ -123,11 +123,11 @@ class ConsoleIOTest extends \PHPUnit_Framework_TestCase
 
     public function testTable()
     {
-        $this->io->table(array('Name', 'Age', 'Favourite food'), array(
-            array('Tom', '30', 'Chocolate'),
-            array('Lisa', '52', 'Strawberries'),
-            array('Adam', '24', 'Bread'),
-        ));
+        $this->io->table(['Name', 'Age', 'Favourite food'], [
+            ['Tom', '30', 'Chocolate'],
+            ['Lisa', '52', 'Strawberries'],
+            ['Adam', '24', 'Bread'],
+        ]);
 
         $this->assertOutputEquals('table');
     }

--- a/tests/IO/ServiceContainer/IOExtensionTest.php
+++ b/tests/IO/ServiceContainer/IOExtensionTest.php
@@ -8,7 +8,7 @@ class IOExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,8 +17,8 @@ class IOExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             IOExtension::SERVICE_IO,
-        );
+        ];
     }
 }

--- a/tests/Logger/LoggerTest.php
+++ b/tests/Logger/LoggerTest.php
@@ -35,7 +35,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     {
         $this->logger->enable(vfsStream::url('root/logs/meteor.log'));
 
-        $this->logger->log(array('test', 'hello', 'goodbye', ''));
+        $this->logger->log(['test', 'hello', 'goodbye', '']);
 
         $expected = <<<LOG
 [2016-07-01T08:00:00+00:00/32.76MB] test

--- a/tests/Logger/ServiceContainer/LoggerExtensionTest.php
+++ b/tests/Logger/ServiceContainer/LoggerExtensionTest.php
@@ -8,7 +8,7 @@ class LoggerExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,8 +17,8 @@ class LoggerExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             LoggerExtension::SERVICE_LOGGER,
-        );
+        ];
     }
 }

--- a/tests/Migrations/Cli/Command/ExecuteMigrationCommandTest.php
+++ b/tests/Migrations/Cli/Command/ExecuteMigrationCommandTest.php
@@ -18,12 +18,12 @@ class ExecuteMigrationCommandTest extends MigrationTestCase
         $this->platform = Mockery::mock('Meteor\Platform\PlatformInterface');
         $this->migrator = Mockery::mock('Meteor\Migrations\Migrator');
 
-        vfsStream::setup('root', null, array(
-            'working' => array(),
-            'install' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'working' => [],
+            'install' => [],
+        ]);
 
-        return new ExecuteMigrationCommand('migrations:execute', array(), new NullIO(), $this->platform, $this->migrator, new NullLogger(), MigrationsConstants::TYPE_DATABASE);
+        return new ExecuteMigrationCommand('migrations:execute', [], new NullIO(), $this->platform, $this->migrator, new NullLogger(), MigrationsConstants::TYPE_DATABASE);
     }
 
     public function testExecuteMigrationUp()
@@ -31,15 +31,15 @@ class ExecuteMigrationCommandTest extends MigrationTestCase
         $workingDir = vfsStream::url('root/working');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'name' => 'test',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-        );
+            ],
+        ];
 
         $this->command->setConfiguration(
             $this->extension->configParse($config)
@@ -50,13 +50,13 @@ class ExecuteMigrationCommandTest extends MigrationTestCase
             ->andReturn(true)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             'package' => 'test',
             'version' => '20160701102030',
             '--up' => null,
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
 
         $this->assertSame(0, $this->tester->getStatusCode());
     }
@@ -66,15 +66,15 @@ class ExecuteMigrationCommandTest extends MigrationTestCase
         $workingDir = vfsStream::url('root/working');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'name' => 'test',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-        );
+            ],
+        ];
 
         $this->command->setConfiguration(
             $this->extension->configParse($config)
@@ -85,13 +85,13 @@ class ExecuteMigrationCommandTest extends MigrationTestCase
             ->andReturn(true)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             'package' => 'test',
             'version' => '20160701102030',
             '--down' => null,
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
 
         $this->assertSame(0, $this->tester->getStatusCode());
     }
@@ -101,15 +101,15 @@ class ExecuteMigrationCommandTest extends MigrationTestCase
         $workingDir = vfsStream::url('root/working');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'name' => 'test',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-        );
+            ],
+        ];
 
         $this->command->setConfiguration(
             $this->extension->configParse($config)
@@ -118,13 +118,13 @@ class ExecuteMigrationCommandTest extends MigrationTestCase
         $this->migrator->shouldReceive('execute')
             ->never();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             'package' => '',
             'version' => '20160701102030',
             '--down' => null,
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
 
         $this->assertSame(1, $this->tester->getStatusCode());
     }

--- a/tests/Migrations/Cli/Command/ExecuteMigrationCommandTest.php
+++ b/tests/Migrations/Cli/Command/ExecuteMigrationCommandTest.php
@@ -119,6 +119,7 @@ class ExecuteMigrationCommandTest extends MigrationTestCase
             ->never();
 
         $this->tester->execute(array(
+            'package' => '',
             'version' => '20160701102030',
             '--down' => null,
             '--working-dir' => $workingDir,

--- a/tests/Migrations/Cli/Command/GenerateMigrationCommandTest.php
+++ b/tests/Migrations/Cli/Command/GenerateMigrationCommandTest.php
@@ -16,28 +16,28 @@ class GenerateMigrationCommandTest extends CommandTestCase
     {
         $this->migrationGenerator = Mockery::mock('Meteor\Migrations\Generator\MigrationGenerator');
 
-        return new GenerateMigrationCommand('migrations:generate', array(), new NullIO(), $this->migrationGenerator, MigrationsConstants::TYPE_DATABASE);
+        return new GenerateMigrationCommand('migrations:generate', [], new NullIO(), $this->migrationGenerator, MigrationsConstants::TYPE_DATABASE);
     }
 
     public function testGeneratesMigration()
     {
         $workingDir = __DIR__;
 
-        $this->command->setConfiguration(array(
-            'migrations' => array(
+        $this->command->setConfiguration([
+            'migrations' => [
                 'name' => 'jadu/xfp',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-        ));
+            ],
+        ]);
 
         $this->migrationGenerator->shouldReceive('generate')
             ->with(Mockery::any(), 'Migrations', $workingDir.'/upgrades')
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
-        ));
+        ]);
     }
 }

--- a/tests/Migrations/Cli/Command/MigrateCommandTest.php
+++ b/tests/Migrations/Cli/Command/MigrateCommandTest.php
@@ -18,12 +18,12 @@ class MigrateCommandTest extends MigrationTestCase
         $this->platform = Mockery::mock('Meteor\Platform\PlatformInterface');
         $this->migrator = Mockery::mock('Meteor\Migrations\Migrator');
 
-        vfsStream::setup('root', null, array(
-            'working' => array(),
-            'install' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'working' => [],
+            'install' => [],
+        ]);
 
-        return new MigrateCommand('migrations:migrate', array(), new NullIO(), $this->platform, $this->migrator, new NullLogger(), MigrationsConstants::TYPE_DATABASE);
+        return new MigrateCommand('migrations:migrate', [], new NullIO(), $this->platform, $this->migrator, new NullLogger(), MigrationsConstants::TYPE_DATABASE);
     }
 
     public function testMigrateRunsMigrationsInOrder()
@@ -31,29 +31,29 @@ class MigrateCommandTest extends MigrationTestCase
         $workingDir = vfsStream::url('root/working');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'name' => 'test',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'test1',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations1',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'test2',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations2',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->command->setConfiguration(
             $this->extension->configParse($config)
@@ -77,9 +77,9 @@ class MigrateCommandTest extends MigrationTestCase
             ->ordered()
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 }

--- a/tests/Migrations/Cli/Command/VersionCommandTest.php
+++ b/tests/Migrations/Cli/Command/VersionCommandTest.php
@@ -17,12 +17,12 @@ class VersionCommandTest extends MigrationTestCase
         $this->platform = Mockery::mock('Meteor\Platform\PlatformInterface');
         $this->versionManager = Mockery::mock('Meteor\Migrations\Version\VersionManager');
 
-        vfsStream::setup('root', null, array(
-            'working' => array(),
-            'install' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'working' => [],
+            'install' => [],
+        ]);
 
-        return new VersionCommand('migrations:version', array(), new NullIO(), $this->platform, $this->versionManager, MigrationsConstants::TYPE_DATABASE);
+        return new VersionCommand('migrations:version', [], new NullIO(), $this->platform, $this->versionManager, MigrationsConstants::TYPE_DATABASE);
     }
 
     public function testMarkMigrated()
@@ -30,15 +30,15 @@ class VersionCommandTest extends MigrationTestCase
         $workingDir = vfsStream::url('root/working');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'name' => 'test',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-        );
+            ],
+        ];
 
         $this->command->setConfiguration(
             $this->extension->configParse($config)
@@ -49,13 +49,13 @@ class VersionCommandTest extends MigrationTestCase
             ->andReturn(true)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             'package' => 'test',
             'version' => '20160701102030',
             '--add' => null,
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 
     public function testMarkNotMigrated()
@@ -63,15 +63,15 @@ class VersionCommandTest extends MigrationTestCase
         $workingDir = vfsStream::url('root/working');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'name' => 'test',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-        );
+            ],
+        ];
 
         $this->command->setConfiguration(
             $this->extension->configParse($config)
@@ -82,13 +82,13 @@ class VersionCommandTest extends MigrationTestCase
             ->andReturn(true)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             'package' => 'test',
             'version' => '20160701102030',
             '--delete' => null,
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 
     public function testMarkAllMigrated()
@@ -96,15 +96,15 @@ class VersionCommandTest extends MigrationTestCase
         $workingDir = vfsStream::url('root/working');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'name' => 'test',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-        );
+            ],
+        ];
 
         $this->command->setConfiguration(
             $this->extension->configParse($config)
@@ -115,13 +115,13 @@ class VersionCommandTest extends MigrationTestCase
             ->andReturn(true)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             'package' => 'test',
             '--add' => null,
             '--all' => true,
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
 
         $this->assertSame(0, $this->tester->getStatusCode());
     }
@@ -131,15 +131,15 @@ class VersionCommandTest extends MigrationTestCase
         $workingDir = vfsStream::url('root/working');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'name' => 'test',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-        );
+            ],
+        ];
 
         $this->command->setConfiguration(
             $this->extension->configParse($config)
@@ -150,13 +150,13 @@ class VersionCommandTest extends MigrationTestCase
             ->andReturn(true)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             'package' => 'test',
             '--delete' => null,
             '--all' => true,
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
 
         $this->assertSame(0, $this->tester->getStatusCode());
     }
@@ -166,15 +166,15 @@ class VersionCommandTest extends MigrationTestCase
         $workingDir = vfsStream::url('root/working');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'name' => 'test',
                 'table' => 'JaduMigrationsXFP',
                 'namespace' => 'Migrations',
                 'directory' => 'upgrades',
-            ),
-        );
+            ],
+        ];
 
         $this->command->setConfiguration(
             $this->extension->configParse($config)
@@ -183,12 +183,12 @@ class VersionCommandTest extends MigrationTestCase
         $this->versionManager->shouldReceive('markAllMigrated')
             ->never();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--add' => null,
             '--all' => true,
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
 
         $this->assertSame(1, $this->tester->getStatusCode());
     }

--- a/tests/Migrations/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Migrations/Configuration/ConfigurationFactoryTest.php
@@ -5,7 +5,6 @@ namespace Meteor\Migrations\Configuration;
 use Meteor\IO\NullIO;
 use Meteor\Migrations\Version\VersionFileManager;
 use Mockery;
-use org\bovigo\vfs\vfsStream;
 
 class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -39,12 +38,12 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $configuration = $this->configurationFactory->createDatabaseConfiguration(
-            array(
+            [
                 'name' => 'jadu/xfp',
                 'namespace' => 'Migrations',
                 'table' => 'JaduMigrationsXFP',
                 'directory' => 'upgrades',
-            ),
+            ],
             __DIR__.'/Fixtures/patch',
             __DIR__.'/Fixtures/install',
             true
@@ -66,21 +65,21 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
             ->andReturn($connection)
             ->once();
 
-        $fileMigrationVersionStorage = Mockery::mock('Meteor\Migrations\Version\FileMigrationVersionStorage', array(
+        $fileMigrationVersionStorage = Mockery::mock('Meteor\Migrations\Version\FileMigrationVersionStorage', [
             'isInitialised' => true,
-        ));
+        ]);
         $this->fileMigrationVersionStorageFactory->shouldReceive('create')
             ->with(__DIR__.'/Fixtures/install', 'JaduMigrationsXFP')
             ->andReturn($fileMigrationVersionStorage)
             ->once();
 
         $configuration = $this->configurationFactory->createFileConfiguration(
-            array(
+            [
                 'name' => 'jadu/xfp',
                 'namespace' => 'Migrations',
                 'table' => 'JaduMigrationsXFP',
                 'directory' => 'upgrades',
-            ),
+            ],
             __DIR__.'/Fixtures/patch',
             __DIR__.'/Fixtures/install',
             true
@@ -103,9 +102,9 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
             ->andReturn($connection)
             ->once();
 
-        $fileMigrationVersionStorage = Mockery::mock('Meteor\Migrations\Version\FileMigrationVersionStorage', array(
+        $fileMigrationVersionStorage = Mockery::mock('Meteor\Migrations\Version\FileMigrationVersionStorage', [
             'isInitialised' => false,
-        ));
+        ]);
 
         $this->fileMigrationVersionStorageFactory->shouldReceive('create')
             ->with(__DIR__.'/Fixtures/install', 'JaduMigrationsXFP')
@@ -122,12 +121,12 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $configuration = $this->configurationFactory->createFileConfiguration(
-            array(
+            [
                 'name' => 'jadu/xfp',
                 'namespace' => 'Migrations',
                 'table' => 'JaduMigrationsXFP',
                 'directory' => 'upgrades',
-            ),
+            ],
             __DIR__.'/Fixtures/patch',
             __DIR__.'/Fixtures/install',
             true

--- a/tests/Migrations/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Migrations/Configuration/ConfigurationFactoryTest.php
@@ -5,6 +5,7 @@ namespace Meteor\Migrations\Configuration;
 use Meteor\IO\NullIO;
 use Meteor\Migrations\Version\VersionFileManager;
 use Mockery;
+use org\bovigo\vfs\vfsStream;
 
 class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -33,7 +34,7 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $connection = Mockery::mock('Doctrine\DBAL\Connection');
         $this->connectionFactory->shouldReceive('getConnection')
-            ->with('/path/to/install')
+            ->with(__DIR__.'/Fixtures/install')
             ->andReturn($connection)
             ->once();
 
@@ -44,8 +45,8 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
                 'table' => 'JaduMigrationsXFP',
                 'directory' => 'upgrades',
             ),
-            '/path/to/patch',
-            '/path/to/install',
+            __DIR__.'/Fixtures/patch',
+            __DIR__.'/Fixtures/install',
             true
         );
 
@@ -53,15 +54,15 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('jadu/xfp', $configuration->getName());
         $this->assertSame('Migrations', $configuration->getMigrationsNamespace());
         $this->assertSame('JaduMigrationsXFP', $configuration->getMigrationsTableName());
-        $this->assertSame('/path/to/patch/upgrades', $configuration->getMigrationsDirectory());
-        $this->assertSame('/path/to/install', $configuration->getJaduPath());
+        $this->assertSame(__DIR__.'/Fixtures/patch/upgrades', $configuration->getMigrationsDirectory());
+        $this->assertSame(__DIR__.'/Fixtures/install', $configuration->getJaduPath());
     }
 
     public function testCreateFileConfiguration()
     {
         $connection = Mockery::mock('Doctrine\DBAL\Connection');
         $this->connectionFactory->shouldReceive('getConnection')
-            ->with('/path/to/install')
+            ->with(__DIR__.'/Fixtures/install')
             ->andReturn($connection)
             ->once();
 
@@ -69,7 +70,7 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
             'isInitialised' => true,
         ));
         $this->fileMigrationVersionStorageFactory->shouldReceive('create')
-            ->with('/path/to/install', 'JaduMigrationsXFP')
+            ->with(__DIR__.'/Fixtures/install', 'JaduMigrationsXFP')
             ->andReturn($fileMigrationVersionStorage)
             ->once();
 
@@ -80,8 +81,8 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
                 'table' => 'JaduMigrationsXFP',
                 'directory' => 'upgrades',
             ),
-            '/path/to/patch',
-            '/path/to/install',
+            __DIR__.'/Fixtures/patch',
+            __DIR__.'/Fixtures/install',
             true
         );
 
@@ -89,8 +90,8 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('jadu/xfp', $configuration->getName());
         $this->assertSame('Migrations', $configuration->getMigrationsNamespace());
         $this->assertSame('JaduMigrationsXFP', $configuration->getMigrationsTableName());
-        $this->assertSame('/path/to/patch/upgrades/filesystem', $configuration->getMigrationsDirectory());
-        $this->assertSame('/path/to/install', $configuration->getJaduPath());
+        $this->assertSame(__DIR__.'/Fixtures/patch/upgrades/filesystem', $configuration->getMigrationsDirectory());
+        $this->assertSame(__DIR__.'/Fixtures/install', $configuration->getJaduPath());
         $this->assertSame($fileMigrationVersionStorage, $configuration->getVersionStorage());
     }
 
@@ -98,7 +99,7 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $connection = Mockery::mock('Doctrine\DBAL\Connection');
         $this->connectionFactory->shouldReceive('getConnection')
-            ->with('/path/to/install')
+            ->with(__DIR__.'/Fixtures/install')
             ->andReturn($connection)
             ->once();
 
@@ -107,12 +108,12 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->fileMigrationVersionStorageFactory->shouldReceive('create')
-            ->with('/path/to/install', 'JaduMigrationsXFP')
+            ->with(__DIR__.'/Fixtures/install', 'JaduMigrationsXFP')
             ->andReturn($fileMigrationVersionStorage)
             ->once();
 
         $this->versionFileManager->shouldReceive('getCurrentVersion')
-            ->with('/path/to/install', 'JaduMigrationsXFP', VersionFileManager::FILE_MIGRATION)
+            ->with(__DIR__.'/Fixtures/install', 'JaduMigrationsXFP', VersionFileManager::FILE_MIGRATION)
             ->andReturn('12345')
             ->once();
 
@@ -127,8 +128,8 @@ class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
                 'table' => 'JaduMigrationsXFP',
                 'directory' => 'upgrades',
             ),
-            '/path/to/patch',
-            '/path/to/install',
+            __DIR__.'/Fixtures/patch',
+            __DIR__.'/Fixtures/install',
             true
         );
     }

--- a/tests/Migrations/Configuration/FileConfigurationTest.php
+++ b/tests/Migrations/Configuration/FileConfigurationTest.php
@@ -11,11 +11,11 @@ class FileConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->configuration = new FileConfiguration(Mockery::mock('Doctrine\DBAL\Connection', array(
+        $this->configuration = new FileConfiguration(Mockery::mock('Doctrine\DBAL\Connection', [
             // Stub methods to satisfy `new Version`
             'getSchemaManager' => Mockery::mock('Doctrine\DBAL\Schema\AbstractSchemaManager'),
             'getDatabasePlatform' => Mockery::mock('Doctrine\DBAL\Platforms\AbstractPlatform'),
-        )));
+        ]));
 
         $this->versionStorage = Mockery::mock('Meteor\Migrations\Version\FileMigrationVersionStorage');
         $this->configuration->setVersionStorage($this->versionStorage);
@@ -40,9 +40,9 @@ class FileConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testHasVersionMigrated()
     {
-        $version = Mockery::mock('Doctrine\DBAL\Migrations\Version', array(
+        $version = Mockery::mock('Doctrine\DBAL\Migrations\Version', [
             'getVersion' => '1',
-        ));
+        ]);
 
         $this->versionStorage->shouldReceive('hasVersionMigrated')
             ->with('1')
@@ -54,7 +54,7 @@ class FileConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMigratedVersions()
     {
-        $versionStrings = array('20160701000000', '20160701000001', '20160701000002', '20160701000003');
+        $versionStrings = ['20160701000000', '20160701000001', '20160701000002', '20160701000003'];
         $this->versionStorage->shouldReceive('getMigratedVersions')
             ->andReturn($versionStrings)
             ->once();

--- a/tests/Migrations/Configuration/FileConfigurationTest.php
+++ b/tests/Migrations/Configuration/FileConfigurationTest.php
@@ -13,8 +13,8 @@ class FileConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $this->configuration = new FileConfiguration(Mockery::mock('Doctrine\DBAL\Connection', array(
             // Stub methods to satisfy `new Version`
-            'getSchemaManager' => null,
-            'getDatabasePlatform' => null,
+            'getSchemaManager' => Mockery::mock('Doctrine\DBAL\Schema\AbstractSchemaManager'),
+            'getDatabasePlatform' => Mockery::mock('Doctrine\DBAL\Platforms\AbstractPlatform'),
         )));
 
         $this->versionStorage = Mockery::mock('Meteor\Migrations\Version\FileMigrationVersionStorage');

--- a/tests/Migrations/Connection/Configuration/Loader/ChainedConfigurationLoaderTest.php
+++ b/tests/Migrations/Connection/Configuration/Loader/ChainedConfigurationLoaderTest.php
@@ -8,83 +8,83 @@ class ChainedConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
 {
     public function testFirstLoaderTakesPrecedence()
     {
-        $loader1 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', array(
-            'load' => array(
+        $loader1 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', [
+            'load' => [
                 'dbname' => 'db1',
                 'user' => 'user1',
                 'password' => 'password1',
                 'host' => 'host1',
                 'driver' => 'driver1',
-            ),
-        ));
-        $loader2 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', array(
-            'load' => array(
+            ],
+        ]);
+        $loader2 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', [
+            'load' => [
                 'dbname' => 'db2',
                 'user' => 'user2',
                 'password' => 'password2',
                 'host' => 'host2',
                 'driver' => 'driver2',
-            ),
-        ));
-        $loader3 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', array(
-            'load' => array(
+            ],
+        ]);
+        $loader3 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', [
+            'load' => [
                 'dbname' => 'db3',
                 'user' => 'user3',
                 'password' => 'password3',
                 'host' => 'host3',
                 'driver' => 'driver3',
-            ),
-        ));
+            ],
+        ]);
 
-        $chainedLoader = new ChainedConfigurationLoader(array($loader1, $loader2, $loader3));
+        $chainedLoader = new ChainedConfigurationLoader([$loader1, $loader2, $loader3]);
 
-        $this->assertSame(array(
+        $this->assertSame([
                 'dbname' => 'db1',
                 'user' => 'user1',
                 'password' => 'password1',
                 'host' => 'host1',
                 'driver' => 'driver1',
-        ), $chainedLoader->load('/path', array()));
+        ], $chainedLoader->load('/path', []));
     }
 
     public function testIgnoresEmptyValues()
     {
-        $loader1 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', array(
-            'load' => array(
+        $loader1 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', [
+            'load' => [
                 'dbname' => '',
                 'user' => 'user1',
                 'password' => '',
                 'host' => 'host1',
                 'driver' => '',
-            ),
-        ));
-        $loader2 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', array(
-            'load' => array(
+            ],
+        ]);
+        $loader2 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', [
+            'load' => [
                 'dbname' => 'db2',
                 'user' => 'user2',
                 'password' => '',
                 'host' => 'host2',
                 'driver' => 'driver2',
-            ),
-        ));
-        $loader3 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', array(
-            'load' => array(
+            ],
+        ]);
+        $loader3 = Mockery::mock('Meteor\Migrations\Connection\Configuration\Loader\ConfigurationLoaderInterface', [
+            'load' => [
                 'dbname' => 'db3',
                 'user' => 'user3',
                 'password' => 'password3',
                 'host' => 'host3',
                 'driver' => 'driver3',
-            ),
-        ));
+            ],
+        ]);
 
-        $chainedLoader = new ChainedConfigurationLoader(array($loader1, $loader2, $loader3));
+        $chainedLoader = new ChainedConfigurationLoader([$loader1, $loader2, $loader3]);
 
-        $this->assertSame(array(
+        $this->assertSame([
                 'dbname' => 'db2',
                 'user' => 'user1',
                 'password' => 'password3',
                 'host' => 'host1',
                 'driver' => 'driver2',
-        ), $chainedLoader->load('/path', array()));
+        ], $chainedLoader->load('/path', []));
     }
 }

--- a/tests/Migrations/Connection/Configuration/Loader/InputOptionConfigurationLoaderTest.php
+++ b/tests/Migrations/Connection/Configuration/Loader/InputOptionConfigurationLoaderTest.php
@@ -28,7 +28,7 @@ class InputOptionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
         $this->io->shouldReceive('hasOption')
             ->andReturn(false);
 
-        $this->assertArraySubset(array('dbname' => 'test'), $this->loader->load('/path'));
+        $this->assertArraySubset(['dbname' => 'test'], $this->loader->load('/path'));
     }
 
     public function testLoadsUser()
@@ -44,7 +44,7 @@ class InputOptionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
         $this->io->shouldReceive('hasOption')
             ->andReturn(false);
 
-        $this->assertArraySubset(array('user' => 'test'), $this->loader->load('/path'));
+        $this->assertArraySubset(['user' => 'test'], $this->loader->load('/path'));
     }
 
     public function testLoadsDbPassword()
@@ -60,7 +60,7 @@ class InputOptionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
         $this->io->shouldReceive('hasOption')
             ->andReturn(false);
 
-        $this->assertArraySubset(array('password' => 'test'), $this->loader->load('/path'));
+        $this->assertArraySubset(['password' => 'test'], $this->loader->load('/path'));
     }
 
     public function testLoadsDbHost()
@@ -76,7 +76,7 @@ class InputOptionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
         $this->io->shouldReceive('hasOption')
             ->andReturn(false);
 
-        $this->assertArraySubset(array('host' => 'test'), $this->loader->load('/path'));
+        $this->assertArraySubset(['host' => 'test'], $this->loader->load('/path'));
     }
 
     public function testLoadDbDriver()
@@ -92,6 +92,6 @@ class InputOptionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
         $this->io->shouldReceive('hasOption')
             ->andReturn(false);
 
-        $this->assertArraySubset(array('driver' => 'test'), $this->loader->load('/path'));
+        $this->assertArraySubset(['driver' => 'test'], $this->loader->load('/path'));
     }
 }

--- a/tests/Migrations/Connection/Configuration/Loader/InputQuestionConfigurationLoaderTest.php
+++ b/tests/Migrations/Connection/Configuration/Loader/InputQuestionConfigurationLoaderTest.php
@@ -21,17 +21,17 @@ class InputQuestionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
             ->andReturn('dbname')
             ->once();
 
-        $configuration = array(
+        $configuration = [
             'dbname' => '',
             'user' => 'user',
             'password' => 'password',
             'host' => 'host',
             'driver' => 'driver',
-        );
+        ];
 
-        $this->assertArraySubset(array(
+        $this->assertArraySubset([
             'dbname' => 'dbname',
-        ), $this->loader->load('install', $configuration));
+        ], $this->loader->load('install', $configuration));
     }
 
     public function testAsksForUserWhenNotSet()
@@ -40,17 +40,17 @@ class InputQuestionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
             ->andReturn('user')
             ->once();
 
-        $configuration = array(
+        $configuration = [
             'dbname' => 'dbname',
             'user' => '',
             'password' => 'password',
             'host' => 'host',
             'driver' => 'driver',
-        );
+        ];
 
-        $this->assertArraySubset(array(
+        $this->assertArraySubset([
             'user' => 'user',
-        ), $this->loader->load('install', $configuration));
+        ], $this->loader->load('install', $configuration));
     }
 
     public function testAsksForPasswordWhenNotSet()
@@ -59,17 +59,17 @@ class InputQuestionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
             ->andReturn('password')
             ->once();
 
-        $configuration = array(
+        $configuration = [
             'dbname' => 'dbname',
             'user' => 'user',
             'password' => '',
             'host' => 'host',
             'driver' => 'driver',
-        );
+        ];
 
-        $this->assertArraySubset(array(
+        $this->assertArraySubset([
             'password' => 'password',
-        ), $this->loader->load('install', $configuration));
+        ], $this->loader->load('install', $configuration));
     }
 
     public function testAsksForHostWhenNotSet()
@@ -78,17 +78,17 @@ class InputQuestionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
             ->andReturn('host')
             ->once();
 
-        $configuration = array(
+        $configuration = [
             'dbname' => 'dbname',
             'user' => 'user',
             'password' => 'password',
             'host' => '',
             'driver' => 'driver',
-        );
+        ];
 
-        $this->assertArraySubset(array(
+        $this->assertArraySubset([
             'host' => 'host',
-        ), $this->loader->load('install', $configuration));
+        ], $this->loader->load('install', $configuration));
     }
 
     public function testAsksForDriverWhenNotSet()
@@ -97,16 +97,16 @@ class InputQuestionConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
             ->andReturn('driver')
             ->once();
 
-        $configuration = array(
+        $configuration = [
             'dbname' => 'dbname',
             'user' => 'user',
             'password' => 'password',
             'host' => 'host',
             'driver' => '',
-        );
+        ];
 
-        $this->assertArraySubset(array(
+        $this->assertArraySubset([
             'driver' => 'driver',
-        ), $this->loader->load('install', $configuration));
+        ], $this->loader->load('install', $configuration));
     }
 }

--- a/tests/Migrations/Connection/Configuration/Loader/SystemConfigurationLoaderTest.php
+++ b/tests/Migrations/Connection/Configuration/Loader/SystemConfigurationLoaderTest.php
@@ -28,19 +28,19 @@ class SystemConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
 </system>
 XML;
 
-        vfsStream::setup('root', null, array(
-            'config' => array(
+        vfsStream::setup('root', null, [
+            'config' => [
                 'system.xml' => $systemXml,
-            ),
-        ));
+            ],
+        ]);
 
-        $this->assertSame(array(
+        $this->assertSame([
             'dbname' => 'jadudb',
             'user' => 'jadu',
             'password' => 'password',
             'host' => 'localhost',
             'driver' => 'pdo_mysql',
-        ), $this->loader->load(vfsStream::url('root')));
+        ], $this->loader->load(vfsStream::url('root')));
     }
 
     public function testUsesPdoMysqlForMysql()
@@ -58,19 +58,19 @@ XML;
 </system>
 XML;
 
-        vfsStream::setup('root', null, array(
-            'config' => array(
+        vfsStream::setup('root', null, [
+            'config' => [
                 'system.xml' => $systemXml,
-            ),
-        ));
+            ],
+        ]);
 
-        $this->assertSame(array(
+        $this->assertSame([
             'dbname' => 'jadudb',
             'user' => 'jadu',
             'password' => 'password',
             'host' => 'localhost',
             'driver' => 'pdo_mysql',
-        ), $this->loader->load(vfsStream::url('root')));
+        ], $this->loader->load(vfsStream::url('root')));
     }
 
     public function testUsesSqlsrvForMssql()
@@ -88,19 +88,19 @@ XML;
 </system>
 XML;
 
-        vfsStream::setup('root', null, array(
-            'config' => array(
+        vfsStream::setup('root', null, [
+            'config' => [
                 'system.xml' => $systemXml,
-            ),
-        ));
+            ],
+        ]);
 
-        $this->assertSame(array(
+        $this->assertSame([
             'dbname' => 'jadudb',
             'user' => 'jadu',
             'password' => 'password',
             'host' => 'localhost',
             'driver' => 'sqlsrv',
-        ), $this->loader->load(vfsStream::url('root')));
+        ], $this->loader->load(vfsStream::url('root')));
     }
 
     public function testLoadDoesNotReturnConfigurationWhenDsnUsed()
@@ -118,12 +118,12 @@ XML;
 </system>
 XML;
 
-        vfsStream::setup('root', null, array(
-            'config' => array(
+        vfsStream::setup('root', null, [
+            'config' => [
                 'system.xml' => $systemXml,
-            ),
-        ));
+            ],
+        ]);
 
-        $this->assertSame(array(), $this->loader->load(vfsStream::url('root')));
+        $this->assertSame([], $this->loader->load(vfsStream::url('root')));
     }
 }

--- a/tests/Migrations/MigratorTest.php
+++ b/tests/Migrations/MigratorTest.php
@@ -22,43 +22,43 @@ class MigratorTest extends \PHPUnit_Framework_TestCase
 
     private function createVersion($versionString)
     {
-        return Mockery::mock('Doctrine\DBAL\Migrations\Version', array(
+        return Mockery::mock('Doctrine\DBAL\Migrations\Version', [
             'getVersion' => $versionString,
             '__toString' => $versionString,
             'getTime' => 5,
-        ));
+        ]);
     }
 
     public function testMigrate()
     {
-        $config = array();
+        $config = [];
 
         $version1 = $this->createVersion('20160701000000');
         $version2 = $this->createVersion('20160702000000');
         $version3 = $this->createVersion('20160703000000');
 
-        $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', array(
-            'getMigrations' => array(
+        $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', [
+            'getMigrations' => [
                 $version1->getVersion() => $version1,
                 $version2->getVersion() => $version2,
                 $version3->getVersion() => $version3,
-            ),
-            'getMigratedVersions' => array(
+            ],
+            'getMigratedVersions' => [
                 $version2->getVersion(),
                 $version3->getVersion(),
-            ),
-            'getAvailableVersions' => array(
+            ],
+            'getAvailableVersions' => [
                 $version1->getVersion(),
                 $version2->getVersion(),
                 $version3->getVersion(),
-            ),
+            ],
             'getCurrentVersion' => $version1->getVersion(),
-            'getMigrationsToExecute' => array(
+            'getMigrationsToExecute' => [
                 $version2,
                 $version3,
-            ),
+            ],
             'resolveVersionAlias' => $version3->getVersion(),
-        ));
+        ]);
 
         $configuration->shouldReceive('formatVersion')
             ->andReturnUsing(function ($version) {
@@ -86,32 +86,32 @@ class MigratorTest extends \PHPUnit_Framework_TestCase
 
     public function testMigrateReturnsTrueWhenNoMigrationsToExecute()
     {
-        $config = array();
+        $config = [];
 
         $version1 = $this->createVersion('20160701000000');
         $version2 = $this->createVersion('20160702000000');
         $version3 = $this->createVersion('20160703000000');
 
-        $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', array(
-            'getMigrations' => array(
+        $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', [
+            'getMigrations' => [
                 $version1->getVersion() => $version1,
                 $version2->getVersion() => $version2,
                 $version3->getVersion() => $version3,
-            ),
-            'getMigratedVersions' => array(
+            ],
+            'getMigratedVersions' => [
                 $version1->getVersion(),
                 $version2->getVersion(),
                 $version3->getVersion(),
-            ),
-            'getAvailableVersions' => array(
+            ],
+            'getAvailableVersions' => [
                 $version1->getVersion(),
                 $version2->getVersion(),
                 $version3->getVersion(),
-            ),
+            ],
             'getCurrentVersion' => $version3->getVersion(),
-            'getMigrationsToExecute' => array(),
+            'getMigrationsToExecute' => [],
             'resolveVersionAlias' => $version3->getVersion(),
-        ));
+        ]);
 
         $configuration->shouldReceive('formatVersion')
             ->andReturnUsing(function ($version) {
@@ -137,7 +137,7 @@ class MigratorTest extends \PHPUnit_Framework_TestCase
 
     public function testExecuteUp()
     {
-        $config = array();
+        $config = [];
 
         $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration');
         $this->configurationFactory->shouldReceive('createConfiguration')
@@ -160,7 +160,7 @@ class MigratorTest extends \PHPUnit_Framework_TestCase
 
     public function testExecuteDown()
     {
-        $config = array();
+        $config = [];
 
         $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration');
         $this->configurationFactory->shouldReceive('createConfiguration')

--- a/tests/Migrations/ServiceContainer/MigrationsExtensionTest.php
+++ b/tests/Migrations/ServiceContainer/MigrationsExtensionTest.php
@@ -8,7 +8,7 @@ class MigrationsExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,7 +17,7 @@ class MigrationsExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             MigrationsExtension::SERVICE_CONFIGURATION_FACTORY,
             MigrationsExtension::SERVICE_CONNECTION_CONFIGURATION_LOADER,
             MigrationsExtension::SERVICE_CONNECTION_CONFIGURATION_LOADER_INPUT_OPTION,
@@ -39,12 +39,12 @@ class MigrationsExtensionTest extends ExtensionTestCase
             MigrationsExtension::SERVICE_STATUS_OUTPUTTER,
             MigrationsExtension::SERVICE_VERSION_FILE_MANAGER,
             MigrationsExtension::SERVICE_VERSION_FILE_MIGRATION_VERSION_STORAGE_FACTORY,
-        );
+        ];
     }
 
     public function testCanOmitMigrationsConfiguration()
     {
-        $config = $this->processConfiguration(array());
+        $config = $this->processConfiguration([]);
 
         $this->assertArrayNotHasKey('migrations', $config);
     }

--- a/tests/Migrations/Version/FileMigrationVersionStorageTest.php
+++ b/tests/Migrations/Version/FileMigrationVersionStorageTest.php
@@ -22,108 +22,108 @@ class FileMigrationVersionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testIsInitialisedReturnsTrueWhenFileExists()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
         $this->assertTrue($this->versionStorage->isInitialised());
     }
 
     public function testHasVersionMigratedReturnsTrueWhenMigrated()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
         $this->assertTrue($this->versionStorage->hasVersionMigrated(2));
     }
 
     public function testHasVersionMigratedReturnsFalseWhenNotMigrated()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
         $this->assertFalse($this->versionStorage->hasVersionMigrated(5));
     }
 
     public function testGetMigratedVersions()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
-        $this->assertSame(array('1', '2', '3'), $this->versionStorage->getMigratedVersions());
+        $this->assertSame(['1', '2', '3'], $this->versionStorage->getMigratedVersions());
     }
 
     public function testGetMigratedVersionsSortsVersions()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "2\n3\n1",
-        ));
+        ]);
 
-        $this->assertSame(array('1', '2', '3'), $this->versionStorage->getMigratedVersions());
+        $this->assertSame(['1', '2', '3'], $this->versionStorage->getMigratedVersions());
     }
 
     public function testGetMigratedVersionsRemovesDuplicates()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3\n2\n3\n1",
-        ));
+        ]);
 
-        $this->assertSame(array('1', '2', '3'), $this->versionStorage->getMigratedVersions());
+        $this->assertSame(['1', '2', '3'], $this->versionStorage->getMigratedVersions());
     }
 
     public function testGetMigratedVersionsNormalisesVersionsFromFile()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1   \n   2\n3",
-        ));
+        ]);
 
-        $this->assertSame(array('1', '2', '3'), $this->versionStorage->getMigratedVersions());
+        $this->assertSame(['1', '2', '3'], $this->versionStorage->getMigratedVersions());
     }
 
     public function testGetNumberOfExecutedMigrations()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
         $this->assertSame(3, $this->versionStorage->getNumberOfExecutedMigrations());
     }
 
     public function testGetCurrentVersionReturnsLatestVersion()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
         $this->assertSame('3', $this->versionStorage->getCurrentVersion());
     }
 
     public function testGetCurrentVersionSortsVersions()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "2\n3\n1",
-        ));
+        ]);
 
         $this->assertSame('3', $this->versionStorage->getCurrentVersion());
     }
 
     public function testGetCurrentVersionReturnsZeroWhenFileIsEmpty()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => '',
-        ));
+        ]);
 
         $this->assertSame('0', $this->versionStorage->getCurrentVersion());
     }
 
     public function testMarkMigrated()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
         $this->versionStorage->markMigrated(4);
 
@@ -132,9 +132,9 @@ class FileMigrationVersionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkMigratedOnlyAddsOnce()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
         $this->versionStorage->markMigrated(4);
         $this->versionStorage->markMigrated(4);
@@ -145,9 +145,9 @@ class FileMigrationVersionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkMigratedAddsInOrder()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n3",
-        ));
+        ]);
 
         $this->versionStorage->markMigrated(2);
 
@@ -165,9 +165,9 @@ class FileMigrationVersionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkNotMigrated()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
         $this->versionStorage->markNotMigrated(2);
 
@@ -176,9 +176,9 @@ class FileMigrationVersionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkNotMigratedDoesNothingWhenVersionNotPresentInFile()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'jadumigrations' => "1\n2\n3",
-        ));
+        ]);
 
         $this->versionStorage->markNotMigrated(4);
 

--- a/tests/Migrations/Version/FileMigrationVersionTest.php
+++ b/tests/Migrations/Version/FileMigrationVersionTest.php
@@ -14,13 +14,13 @@ class FileMigrationVersionTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->configuration = Mockery::mock('Doctrine\DBAL\Migrations\Configuration\Configuration', array(
-            'getConnection' => Mockery::mock('Doctrine\DBAL\Connection', array(
+        $this->configuration = Mockery::mock('Doctrine\DBAL\Migrations\Configuration\Configuration', [
+            'getConnection' => Mockery::mock('Doctrine\DBAL\Connection', [
                 'getDatabasePlatform' => Mockery::mock('Doctrine\DBAL\Platforms\AbstractPlatform'),
                 'getSchemaManager' => Mockery::mock('Doctrine\DBAL\Schema\AbstractSchemaManager'),
-            )),
+            ]),
             'getOutputWriter' => Mockery::mock('Doctrine\DBAL\Migrations\OutputWriter'),
-        ));
+        ]);
         $this->versionStorage = Mockery::mock('Meteor\Migrations\Version\FileMigrationVersionStorage');
         $this->version = new FileMigrationVersion($this->configuration, '12345', 'stdClass', null, $this->versionStorage);
     }

--- a/tests/Migrations/Version/FileMigrationVersionTest.php
+++ b/tests/Migrations/Version/FileMigrationVersionTest.php
@@ -17,12 +17,12 @@ class FileMigrationVersionTest extends \PHPUnit_Framework_TestCase
         $this->configuration = Mockery::mock('Doctrine\DBAL\Migrations\Configuration\Configuration', array(
             'getConnection' => Mockery::mock('Doctrine\DBAL\Connection', array(
                 'getDatabasePlatform' => Mockery::mock('Doctrine\DBAL\Platforms\AbstractPlatform'),
-                'getSchemaManager' => Mockery::mock('Doctrine\DBAL\Schama\AbstractSchemaManager'),
+                'getSchemaManager' => Mockery::mock('Doctrine\DBAL\Schema\AbstractSchemaManager'),
             )),
             'getOutputWriter' => Mockery::mock('Doctrine\DBAL\Migrations\OutputWriter'),
         ));
         $this->versionStorage = Mockery::mock('Meteor\Migrations\Version\FileMigrationVersionStorage');
-        $this->version = new FileMigrationVersion($this->configuration, '12345', 'stdClass', $this->versionStorage);
+        $this->version = new FileMigrationVersion($this->configuration, '12345', 'stdClass', null, $this->versionStorage);
     }
 
     public function testMarkMigrated()

--- a/tests/Migrations/Version/VersionFileManagerTest.php
+++ b/tests/Migrations/Version/VersionFileManagerTest.php
@@ -29,80 +29,80 @@ class VersionFileManagerTest extends \PHPUnit_Framework_TestCase
 
     public function getCurrentVersionProvider()
     {
-        return array(
-            array(
-                array('MIGRATION_NUMBER' => '20160701102030'),
+        return [
+            [
+                ['MIGRATION_NUMBER' => '20160701102030'],
                 'JaduMigrations',
                 VersionFileManager::DATABASE_MIGRATION,
                 '20160701102030',
-            ),
-            array(
-                array(),
+            ],
+            [
+                [],
                 'JaduMigrations',
                 VersionFileManager::DATABASE_MIGRATION,
                 '0',
-            ),
-            array(
-                array('XFP_MIGRATION_NUMBER' => '20160701102030'),
+            ],
+            [
+                ['XFP_MIGRATION_NUMBER' => '20160701102030'],
                 'JaduMigrationsXFP',
                 VersionFileManager::DATABASE_MIGRATION,
                 '20160701102030',
-            ),
-            array(
-                array(),
+            ],
+            [
+                [],
                 'JaduMigrationsXFP',
                 VersionFileManager::DATABASE_MIGRATION,
                 '0',
-            ),
-            array(
-                array('SPACECRAFTCUSTOMMIGRATIONS_MIGRATION_NUMBER' => '20160701102030'),
+            ],
+            [
+                ['SPACECRAFTCUSTOMMIGRATIONS_MIGRATION_NUMBER' => '20160701102030'],
                 'SpacecraftCustomMigrations',
                 VersionFileManager::DATABASE_MIGRATION,
                 '20160701102030',
-            ),
-            array(
-                array(),
+            ],
+            [
+                [],
                 'SpacecraftCustomMigrations',
                 VersionFileManager::DATABASE_MIGRATION,
                 '0',
-            ),
-            array(
-                array('FILE_SYSTEM_MIGRATION_NUMBER' => '20160701102030'),
+            ],
+            [
+                ['FILE_SYSTEM_MIGRATION_NUMBER' => '20160701102030'],
                 'JaduMigrations',
                 VersionFileManager::FILE_MIGRATION,
                 '20160701102030',
-            ),
-            array(
-                array(),
+            ],
+            [
+                [],
                 'JaduMigrations',
                 VersionFileManager::FILE_MIGRATION,
                 '0',
-            ),
-            array(
-                array('XFP_FILE_SYSTEM_MIGRATION_NUMBER' => '20160701102030'),
+            ],
+            [
+                ['XFP_FILE_SYSTEM_MIGRATION_NUMBER' => '20160701102030'],
                 'JaduMigrationsXFP',
                 VersionFileManager::FILE_MIGRATION,
                 '20160701102030',
-            ),
-            array(
-                array(),
+            ],
+            [
+                [],
                 'JaduMigrationsXFP',
                 VersionFileManager::FILE_MIGRATION,
                 '0',
-            ),
-            array(
-                array('SPACECRAFTCUSTOMMIGRATIONS_FILE_SYSTEM_MIGRATION_NUMBER' => '20160701102030'),
+            ],
+            [
+                ['SPACECRAFTCUSTOMMIGRATIONS_FILE_SYSTEM_MIGRATION_NUMBER' => '20160701102030'],
                 'SpacecraftCustomMigrations',
                 VersionFileManager::FILE_MIGRATION,
                 '20160701102030',
-            ),
-            array(
-                array(),
+            ],
+            [
+                [],
                 'SpacecraftCustomMigrations',
                 VersionFileManager::FILE_MIGRATION,
                 '0',
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -119,37 +119,37 @@ class VersionFileManagerTest extends \PHPUnit_Framework_TestCase
 
     public function setCurrentVersionProvider()
     {
-        return array(
-            array(
+        return [
+            [
                 'JaduMigrations',
                 VersionFileManager::DATABASE_MIGRATION,
                 'MIGRATION_NUMBER',
-            ),
-            array(
+            ],
+            [
                 'JaduMigrationsXFP',
                 VersionFileManager::DATABASE_MIGRATION,
                 'XFP_MIGRATION_NUMBER',
-            ),
-            array(
+            ],
+            [
                 'SpacecraftCustomMigrations',
                 VersionFileManager::DATABASE_MIGRATION,
                 'SPACECRAFTCUSTOMMIGRATIONS_MIGRATION_NUMBER',
-            ),
-            array(
+            ],
+            [
                 'JaduMigrations',
                 VersionFileManager::FILE_MIGRATION,
                 'FILE_SYSTEM_MIGRATION_NUMBER',
-            ),
-            array(
+            ],
+            [
                 'JaduMigrationsXFP',
                 VersionFileManager::FILE_MIGRATION,
                 'XFP_FILE_SYSTEM_MIGRATION_NUMBER',
-            ),
-            array(
+            ],
+            [
                 'SpacecraftCustomMigrations',
                 VersionFileManager::FILE_MIGRATION,
                 'SPACECRAFTCUSTOMMIGRATIONS_FILE_SYSTEM_MIGRATION_NUMBER',
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/tests/Migrations/Version/VersionManagerTest.php
+++ b/tests/Migrations/Version/VersionManagerTest.php
@@ -20,16 +20,16 @@ class VersionManagerTest extends \PHPUnit_Framework_TestCase
 
     private function createVersion($versionString)
     {
-        return Mockery::mock('Doctrine\DBAL\Migrations\Version', array(
+        return Mockery::mock('Doctrine\DBAL\Migrations\Version', [
             'getVersion' => $versionString,
             '__toString' => $versionString,
             'getTime' => 5,
-        ));
+        ]);
     }
 
     public function testMarkMigrated()
     {
-        $config = array();
+        $config = [];
 
         $version = $this->createVersion('20160701000000');
 
@@ -63,7 +63,7 @@ class VersionManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkMigratedReturnsFalseWhenVersionHasBeenMigrated()
     {
-        $config = array();
+        $config = [];
 
         $version = $this->createVersion('20160701000000');
 
@@ -94,7 +94,7 @@ class VersionManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkMigratedReturnsFalseWhenVersionNotFound()
     {
-        $config = array();
+        $config = [];
 
         $version = $this->createVersion('20160701000000');
 
@@ -115,7 +115,7 @@ class VersionManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkNotMigrated()
     {
-        $config = array();
+        $config = [];
 
         $version = $this->createVersion('20160701000000');
 
@@ -149,7 +149,7 @@ class VersionManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkNotMigratedReturnsFalseWhenVersionHasNotBeenMigrated()
     {
-        $config = array();
+        $config = [];
 
         $version = $this->createVersion('20160701000000');
 
@@ -180,7 +180,7 @@ class VersionManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkNotMigratedReturnsFalseWhenVersionNotFound()
     {
-        $config = array();
+        $config = [];
 
         $version = $this->createVersion('20160701000000');
 
@@ -201,19 +201,19 @@ class VersionManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkAllMigrated()
     {
-        $config = array();
+        $config = [];
 
         $version1 = $this->createVersion('20160701000000');
         $version2 = $this->createVersion('20160702000000');
         $version3 = $this->createVersion('20160703000000');
 
-        $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', array(
-            'getAvailableVersions' => array(
+        $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', [
+            'getAvailableVersions' => [
                 $version1->getVersion(),
                 $version2->getVersion(),
                 $version3->getVersion(),
-            ),
-        ));
+            ],
+        ]);
 
         $this->configurationFactory->shouldReceive('createConfiguration')
             ->with(MigrationsConstants::TYPE_DATABASE, $config, 'patch', 'install')
@@ -264,19 +264,19 @@ class VersionManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testMarkAllNotMigrated()
     {
-        $config = array();
+        $config = [];
 
         $version1 = $this->createVersion('20160701000000');
         $version2 = $this->createVersion('20160702000000');
         $version3 = $this->createVersion('20160703000000');
 
-        $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', array(
-            'getAvailableVersions' => array(
+        $configuration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', [
+            'getAvailableVersions' => [
                 $version1->getVersion(),
                 $version2->getVersion(),
                 $version3->getVersion(),
-            ),
-        ));
+            ],
+        ]);
 
         $this->configurationFactory->shouldReceive('createConfiguration')
             ->with(MigrationsConstants::TYPE_DATABASE, $config, 'patch', 'install')

--- a/tests/Package/Cli/Command/PackageCommandTest.php
+++ b/tests/Package/Cli/Command/PackageCommandTest.php
@@ -14,7 +14,7 @@ class PackageCommandTest extends CommandTestCase
     {
         $this->packageCreator = Mockery::mock('Meteor\Package\PackageCreator');
 
-        return new PackageCommand(null, array('name' => 'test'), new NullIO(), $this->packageCreator);
+        return new PackageCommand(null, ['name' => 'test'], new NullIO(), $this->packageCreator);
     }
 
     public function testCreatesPackage()
@@ -27,25 +27,25 @@ class PackageCommandTest extends CommandTestCase
                 $workingDir,
                 $outputDir,
                 'package.zip',
-                array('name' => 'test'),
-                array(
+                ['name' => 'test'],
+                [
                     '/path/to/package1.zip',
                     '/path/to/package2.zip',
-                ),
+                ],
                 false,
                 null
             )
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--output-dir' => $outputDir,
             '--filename' => 'package.zip',
-            '--combine' => array(
+            '--combine' => [
                 '/path/to/package1.zip',
                 '/path/to/package2.zip',
-            ),
-        ));
+            ],
+        ]);
     }
 
     public function testCreatesPackageWithoutCombiningPackages()
@@ -58,19 +58,19 @@ class PackageCommandTest extends CommandTestCase
                 $workingDir,
                 $outputDir,
                 'package.zip',
-                array('name' => 'test'),
-                array(),
+                ['name' => 'test'],
+                [],
                 true,
                 null
             )
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--output-dir' => $outputDir,
             '--filename' => 'package.zip',
             '--skip-combine' => true,
-        ));
+        ]);
     }
 
     public function testCreatesPackageWithPhar()
@@ -83,18 +83,18 @@ class PackageCommandTest extends CommandTestCase
                 $workingDir,
                 $outputDir,
                 'package.zip',
-                array('name' => 'test'),
-                array(),
+                ['name' => 'test'],
+                [],
                 false,
                 '/path/to/meteor.phar'
             )
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--output-dir' => $outputDir,
             '--filename' => 'package.zip',
             '--phar' => '/path/to/meteor.phar',
-        ));
+        ]);
     }
 }

--- a/tests/Package/Combined/CombinedPackageDependencyCheckerTest.php
+++ b/tests/Package/Combined/CombinedPackageDependencyCheckerTest.php
@@ -17,23 +17,23 @@ class CombinedPackageDependencyCheckerTest extends \PHPUnit_Framework_TestCase
 
     public function testCheckWhenHasNoRequirements()
     {
-        $this->assertTrue($this->checker->check(vfsStream::url('root'), array()));
+        $this->assertTrue($this->checker->check(vfsStream::url('root'), []));
     }
 
     public function testCheckWhenRequirementsMet()
     {
-        $config = array(
-            'package' => array(
-                'combine' => array(
+        $config = [
+            'package' => [
+                'combine' => [
                     'jadu/cms' => '13.7.0',
-                ),
-            ),
-            'combined' => array(
-                array(
+                ],
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/cms',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $this->assertTrue($this->checker->check(vfsStream::url('root'), $config));
     }
@@ -43,13 +43,13 @@ class CombinedPackageDependencyCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCheckThrowsExceptionWhenRequiredPackageMissing()
     {
-        $config = array(
-            'package' => array(
-                'combine' => array(
+        $config = [
+            'package' => [
+                'combine' => [
                     'jadu/cms' => '13.7.0',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $this->assertTrue($this->checker->check(vfsStream::url('root'), $config));
     }
@@ -59,50 +59,50 @@ class CombinedPackageDependencyCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testChecksRequirementsRecursively()
     {
-        $config = array(
-            'package' => array(
-                'combine' => array(
+        $config = [
+            'package' => [
+                'combine' => [
                     'jadu/xfp' => '3.7.0',
-                ),
-            ),
-            'combined' => array(
-                array(
+                ],
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                    'package' => array(
-                        'combine' => array(
+                    'package' => [
+                        'combine' => [
                             'jadu/cms' => '13.7.0',
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        ],
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertTrue($this->checker->check(vfsStream::url('root'), $config));
     }
 
     public function testCheckWhenVersionRequirementsMet()
     {
-        $config = array(
-            'package' => array(
-                'combine' => array(
+        $config = [
+            'package' => [
+                'combine' => [
                     'jadu/cms' => '13.7.0',
-                ),
-            ),
-            'combined' => array(
-                array(
+                ],
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/cms',
-                    'package' => array(
+                    'package' => [
                         'version' => 'VERSION',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'to_patch' => [
                 'VERSION' => '13.7.0',
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertTrue($this->checker->check(vfsStream::url('root'), $config));
     }
@@ -112,27 +112,27 @@ class CombinedPackageDependencyCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCheckThrowsExceptionWhenVersionRequirementIsNotMet()
     {
-        $config = array(
-            'package' => array(
-                'combine' => array(
+        $config = [
+            'package' => [
+                'combine' => [
                     'jadu/cms' => '13.7.0',
-                ),
-            ),
-            'combined' => array(
-                array(
+                ],
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/cms',
-                    'package' => array(
+                    'package' => [
                         'version' => 'VERSION',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'to_patch' => [
                 'VERSION' => '13.5.0',
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertTrue($this->checker->check(vfsStream::url('root'), $config));
     }
@@ -142,37 +142,37 @@ class CombinedPackageDependencyCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testChecksVersionRequirementsRecursively()
     {
-        $config = array(
-            'package' => array(
-                'combine' => array(
+        $config = [
+            'package' => [
+                'combine' => [
                     'jadu/xfp' => '3.7.0',
-                ),
-            ),
-            'combined' => array(
-                array(
+                ],
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'XFP_VERSION',
-                        'combine' => array(
+                        'combine' => [
                             'jadu/cms' => '13.7.0',
-                        ),
-                    ),
-                ),
-                array(
+                        ],
+                    ],
+                ],
+                [
                     'name' => 'jadu/cms',
-                    'package' => array(
+                    'package' => [
                         'version' => 'VERSION',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'to_patch' => [
                 'XFP_VERSION' => '3.7.0',
                 'VERSION' => '12.0.0',
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertTrue($this->checker->check(vfsStream::url('root'), $config));
     }

--- a/tests/Package/Combined/CombinedPackageResolverTest.php
+++ b/tests/Package/Combined/CombinedPackageResolverTest.php
@@ -16,9 +16,9 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->packageCombiner = Mockery::mock('Meteor\Package\Combined\PackageCombiner');
-        $this->combinedPackageDependencyChecker = Mockery::mock('Meteor\Package\Combined\CombinedPackageDependencyChecker', array(
+        $this->combinedPackageDependencyChecker = Mockery::mock('Meteor\Package\Combined\CombinedPackageDependencyChecker', [
             'check' => null,
-        ));
+        ]);
         $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem');
         $this->packageProvider = Mockery::mock('Meteor\Package\Provider\PackageProviderInterface');
 
@@ -36,16 +36,16 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
         $outputDir = 'output';
         $tempDir = 'temp';
 
-        $config = array(
+        $config = [
             'name' => 'test',
-        );
+        ];
 
         $updatedConfig = $config;
-        $updatedConfig['combined'] = array(
-            array(
+        $updatedConfig['combined'] = [
+            [
                 'name' => 'jadu/cms',
-            ),
-        );
+            ],
+        ];
 
         $this->packageCombiner->shouldReceive('combine')
             ->with('cms.zip', $outputDir, $tempDir, $config, true)
@@ -56,7 +56,7 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
             ->with($tempDir, $updatedConfig)
             ->once();
 
-        $this->assertSame($updatedConfig, $this->combinedPackageResolver->resolve(array('cms.zip'), $outputDir, $tempDir, $config, true));
+        $this->assertSame($updatedConfig, $this->combinedPackageResolver->resolve(['cms.zip'], $outputDir, $tempDir, $config, true));
     }
 
     public function testResolveDoesNotDownloadPackageIfAlreadyCombined()
@@ -64,21 +64,21 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
         $outputDir = 'output';
         $tempDir = 'temp';
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'package' => array(
-                'combine' => array(
+            'package' => [
+                'combine' => [
                     'jadu/cms' => '13.6.0',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $updatedConfig = $config;
-        $updatedConfig['combined'] = array(
-            array(
+        $updatedConfig['combined'] = [
+            [
                 'name' => 'jadu/cms',
-            ),
-        );
+            ],
+        ];
 
         $this->packageCombiner->shouldReceive('combine')
             ->with('cms.zip', $outputDir, $tempDir, $config, true)
@@ -92,7 +92,7 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
             ->with($tempDir, $updatedConfig)
             ->once();
 
-        $this->assertSame($updatedConfig, $this->combinedPackageResolver->resolve(array('cms.zip'), $outputDir, $tempDir, $config, true));
+        $this->assertSame($updatedConfig, $this->combinedPackageResolver->resolve(['cms.zip'], $outputDir, $tempDir, $config, true));
     }
 
     public function testResolveDoesNotDownloadPackageIfAlreadyCombinedViaAnotherCombinedPackage()
@@ -100,24 +100,24 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
         $outputDir = 'output';
         $tempDir = 'temp';
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'package' => array(
-                'combine' => array(
+            'package' => [
+                'combine' => [
                     'jadu/xfp' => '3.2.1',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $updatedConfig = $config;
-        $updatedConfig['combined'] = array(
-            array(
+        $updatedConfig['combined'] = [
+            [
                 'name' => 'jadu/cms',
-            ),
-            array(
+            ],
+            [
                 'name' => 'jadu/xfp',
-            ),
-        );
+            ],
+        ];
 
         $this->packageCombiner->shouldReceive('combine')
             ->with('xfp.zip', $outputDir, $tempDir, $config, true)
@@ -131,7 +131,7 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
             ->with($tempDir, $updatedConfig)
             ->once();
 
-        $this->assertSame($updatedConfig, $this->combinedPackageResolver->resolve(array('xfp.zip'), $outputDir, $tempDir, $config, true));
+        $this->assertSame($updatedConfig, $this->combinedPackageResolver->resolve(['xfp.zip'], $outputDir, $tempDir, $config, true));
     }
 
     public function testResolveDownloadsPackages()
@@ -139,21 +139,21 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
         $outputDir = 'output';
         $tempDir = 'temp';
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'package' => array(
-                'combine' => array(
+            'package' => [
+                'combine' => [
                     'jadu/cms' => '13.6.0',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $updatedConfig = $config;
-        $updatedConfig['combined'] = array(
-            array(
+        $updatedConfig['combined'] = [
+            [
                 'name' => 'jadu/cms',
-            ),
-        );
+            ],
+        ];
 
         $this->filesystem->shouldReceive('createTempDirectory')
             ->with($outputDir)
@@ -177,7 +177,7 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
             ->with($tempDir, $updatedConfig)
             ->once();
 
-        $this->assertSame($updatedConfig, $this->combinedPackageResolver->resolve(array(), $outputDir, $tempDir, $config, true));
+        $this->assertSame($updatedConfig, $this->combinedPackageResolver->resolve([], $outputDir, $tempDir, $config, true));
     }
 
     public function testChecksPackageDependencies()
@@ -185,14 +185,14 @@ class CombinedPackageResolverTest extends \PHPUnit_Framework_TestCase
         $outputDir = 'output';
         $tempDir = 'temp';
 
-        $config = array(
+        $config = [
             'name' => 'test',
-        );
+        ];
 
         $this->combinedPackageDependencyChecker->shouldReceive('check')
             ->with($tempDir, $config)
             ->once();
 
-        $this->combinedPackageResolver->resolve(array(), $outputDir, $tempDir, $config, true);
+        $this->combinedPackageResolver->resolve([], $outputDir, $tempDir, $config, true);
     }
 }

--- a/tests/Package/Combined/PackageCombinerTest.php
+++ b/tests/Package/Combined/PackageCombinerTest.php
@@ -37,16 +37,16 @@ class PackageCombinerTest extends \PHPUnit_Framework_TestCase
     public function testCombine()
     {
         $packagePath = '/path/to/package.zip';
-        $packageConfig = array(
+        $packageConfig = [
             'name' => 'jadu/xfp',
-        );
+        ];
 
         $outputDir = 'output';
         $tempDir = '/tmp/working';
         $extractedDir = '/tmp/extracted';
-        $config = array(
+        $config = [
             'name' => 'client',
-        );
+        ];
 
         $this->filesystem->shouldReceive('createTempDirectory')
             ->with($outputDir)
@@ -67,7 +67,7 @@ class PackageCombinerTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->filesystem->shouldReceive('copyDirectory')
-            ->with($extractedDir.'/to_patch', $tempDir.'/to_patch', array('/**'))
+            ->with($extractedDir.'/to_patch', $tempDir.'/to_patch', ['/**'])
             ->ordered()
             ->once();
 
@@ -84,29 +84,29 @@ class PackageCombinerTest extends \PHPUnit_Framework_TestCase
 
         $updatedConfig = $this->packageCombiner->combine($packagePath, $outputDir, $tempDir, $config, false);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'name' => 'client',
-            'combined' => array(
-                array(
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                ),
-            ),
-        ), $updatedConfig);
+                ],
+            ],
+        ], $updatedConfig);
     }
 
     public function testCombineExcludesVendor()
     {
         $packagePath = '/path/to/package.zip';
-        $packageConfig = array(
+        $packageConfig = [
             'name' => 'jadu/xfp',
-        );
+        ];
 
         $outputDir = 'output';
         $tempDir = '/tmp/working';
         $extractedDir = '/tmp/extracted';
-        $config = array(
+        $config = [
             'name' => 'client',
-        );
+        ];
 
         $this->filesystem->shouldReceive('createTempDirectory')
             ->with($outputDir)
@@ -127,7 +127,7 @@ class PackageCombinerTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->filesystem->shouldReceive('copyDirectory')
-            ->with($extractedDir.'/to_patch', $tempDir.'/to_patch', array('/**', '!/vendor'))
+            ->with($extractedDir.'/to_patch', $tempDir.'/to_patch', ['/**', '!/vendor'])
             ->ordered()
             ->once();
 
@@ -144,34 +144,34 @@ class PackageCombinerTest extends \PHPUnit_Framework_TestCase
 
         $updatedConfig = $this->packageCombiner->combine($packagePath, $outputDir, $tempDir, $config, true);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'name' => 'client',
-            'combined' => array(
-                array(
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                ),
-            ),
-        ), $updatedConfig);
+                ],
+            ],
+        ], $updatedConfig);
     }
 
     public function testCombineHoistsCombinedPackages()
     {
         $packagePath = '/path/to/package.zip';
-        $packageConfig = array(
+        $packageConfig = [
             'name' => 'jadu/xfp',
-            'combined' => array(
-                array(
+            'combined' => [
+                [
                     'name' => 'jadu/cms',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $outputDir = 'output';
         $tempDir = '/tmp/working';
         $extractedDir = '/tmp/extracted';
-        $config = array(
+        $config = [
             'name' => 'client',
-        );
+        ];
 
         $this->filesystem->shouldReceive('createTempDirectory')
             ->with($outputDir)
@@ -214,42 +214,42 @@ class PackageCombinerTest extends \PHPUnit_Framework_TestCase
 
         $updatedConfig = $this->packageCombiner->combine($packagePath, $outputDir, $tempDir, $config, false);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'name' => 'client',
-            'combined' => array(
-                array(
+            'combined' => [
+                [
                     'name' => 'jadu/cms',
-                ),
-                array(
+                ],
+                [
                     'name' => 'jadu/xfp',
-                ),
-            ),
-        ), $updatedConfig);
+                ],
+            ],
+        ], $updatedConfig);
     }
 
     public function testIgnoresAlreadyCombinedPackages()
     {
         $packagePath = '/path/to/package.zip';
-        $packageConfig = array(
+        $packageConfig = [
             'name' => 'jadu/xfp',
-            'combined' => array(
-                array(
+            'combined' => [
+                [
                     'name' => 'jadu/cms',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $outputDir = 'output';
         $tempDir = '/tmp/working';
         $extractedDir = '/tmp/extracted';
-        $config = array(
+        $config = [
             'name' => 'client',
-            'combined' => array(
-                array(
+            'combined' => [
+                [
                     'name' => 'jadu/cms',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $this->filesystem->shouldReceive('createTempDirectory')
             ->with($outputDir)
@@ -291,17 +291,17 @@ class PackageCombinerTest extends \PHPUnit_Framework_TestCase
 
         $updatedConfig = $this->packageCombiner->combine($packagePath, $outputDir, $tempDir, $config, false);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'name' => 'client',
-            'combined' => array(
-                array(
+            'combined' => [
+                [
                     'name' => 'jadu/cms',
-                ),
-                array(
+                ],
+                [
                     'name' => 'jadu/xfp',
-                ),
-            ),
-        ), $updatedConfig);
+                ],
+            ],
+        ], $updatedConfig);
     }
 
     public function testCombineDoesNotRemovePackageIfAlreadyExtracted()
@@ -309,15 +309,15 @@ class PackageCombinerTest extends \PHPUnit_Framework_TestCase
         vfsStream::setup('root');
 
         $packagePath = vfsStream::url('root');
-        $packageConfig = array(
+        $packageConfig = [
             'name' => 'jadu/xfp',
-        );
+        ];
 
         $outputDir = 'output';
         $tempDir = '/tmp/working';
-        $config = array(
+        $config = [
             'name' => 'client',
-        );
+        ];
 
         $this->filesystem->shouldReceive('createTempDirectory')
             ->never();
@@ -348,13 +348,13 @@ class PackageCombinerTest extends \PHPUnit_Framework_TestCase
 
         $updatedConfig = $this->packageCombiner->combine($packagePath, $outputDir, $tempDir, $config, false);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'name' => 'client',
-            'combined' => array(
-                array(
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                ),
-            ),
-        ), $updatedConfig);
+                ],
+            ],
+        ], $updatedConfig);
     }
 }

--- a/tests/Package/Composer/ComposerDependencyCheckerTest.php
+++ b/tests/Package/Composer/ComposerDependencyCheckerTest.php
@@ -17,9 +17,9 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetRequirementsReturnsRequirements()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'composer.json' => file_get_contents(__DIR__.'/Fixtures/composer.json'),
-        ));
+        ]);
 
         $requirements = $this->checker->getRequirements(vfsStream::url('root'));
 
@@ -39,9 +39,9 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetRequirementsIgnoresPhpExtensionRequirements()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'composer.json' => file_get_contents(__DIR__.'/Fixtures/composer.json'),
-        ));
+        ]);
 
         $requirements = $this->checker->getRequirements(vfsStream::url('root'));
 
@@ -57,7 +57,7 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     {
         vfsStream::setup('root');
 
-        $this->assertSame(array(), $this->checker->getRequirements(vfsStream::url('root')));
+        $this->assertSame([], $this->checker->getRequirements(vfsStream::url('root')));
     }
 
     /**
@@ -65,98 +65,98 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetRequirementsThrowsExceptionWhenComposerJsonCannotBeParsed()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'composer.json' => '!!!',
-        ));
+        ]);
 
         $this->checker->getRequirements(vfsStream::url('root'));
     }
 
     public function testAddRequirements()
     {
-        $requirements = array(
+        $requirements = [
             new ComposerRequirement('jadu/cms-dependencies', '~13.6.0'),
             new ComposerRequirement('symfony/symfony', '~2.6.11'),
-        );
+        ];
 
-        $this->assertSame(array(
-            'package' => array(
-                'composer' => array(
+        $this->assertSame([
+            'package' => [
+                'composer' => [
                     'jadu/cms-dependencies' => '~13.6.0',
                     'symfony/symfony' => '~2.6.11',
-                ),
-            ),
-        ), $this->checker->addRequirements($requirements, array()));
+                ],
+            ],
+        ], $this->checker->addRequirements($requirements, []));
     }
 
     public function testAddRequirementsReplacesExistingRequirements()
     {
-        $requirements = array(
+        $requirements = [
             new ComposerRequirement('jadu/cms-dependencies', '~13.6.0'),
             new ComposerRequirement('symfony/symfony', '~2.6.11'),
-        );
+        ];
 
-        $config = array(
-            'package' => array(
-                'composer' => array(
+        $config = [
+            'package' => [
+                'composer' => [
                     'guzzle/guzzle' => '^3.0',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
-        $this->assertSame(array(
-            'package' => array(
-                'composer' => array(
+        $this->assertSame([
+            'package' => [
+                'composer' => [
                     'jadu/cms-dependencies' => '~13.6.0',
                     'symfony/symfony' => '~2.6.11',
-                ),
-            ),
-        ), $this->checker->addRequirements($requirements, $config));
+                ],
+            ],
+        ], $this->checker->addRequirements($requirements, $config));
     }
 
     public function testCheckWhenHasNoRequirementsAndLockFileMissing()
     {
-        $this->checker->check(vfsStream::url('root'), array());
+        $this->checker->check(vfsStream::url('root'), []);
     }
 
     public function testCheckWhenRequiredPackagesInLockFile()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'composer.lock' => file_get_contents(__DIR__.'/Fixtures/composer.lock'),
-        ));
+        ]);
 
-        $this->checker->check(vfsStream::url('root'), array(
-            'combined' => array(
-                array(
+        $this->checker->check(vfsStream::url('root'), [
+            'combined' => [
+                [
                     'name' => 'test1',
-                    'package' => array(
-                        'composer' => array(
+                    'package' => [
+                        'composer' => [
                             'jadu/cms-dependencies' => '~13.6.0',
-                        ),
-                    ),
-                ),
-            ),
-        ));
+                        ],
+                    ],
+                ],
+            ],
+        ]);
     }
 
     public function testCheckIsCaseInsensitive()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'composer.lock' => file_get_contents(__DIR__.'/Fixtures/composer.lock'),
-        ));
+        ]);
 
-        $this->checker->check(vfsStream::url('root'), array(
-            'combined' => array(
-                array(
+        $this->checker->check(vfsStream::url('root'), [
+            'combined' => [
+                [
                     'name' => 'test1',
-                    'package' => array(
-                        'composer' => array(
+                    'package' => [
+                        'composer' => [
                             'jadu/CMS-dependencies' => '~13.6.0',
-                        ),
-                    ),
-                ),
-            ),
-        ));
+                        ],
+                    ],
+                ],
+            ],
+        ]);
     }
 
     /**
@@ -164,22 +164,22 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCheckThrowsExceptionWhenComposerLockCannotBeParsed()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'composer.lock' => '!!!',
-        ));
+        ]);
 
-        $this->checker->check(vfsStream::url('root'), array(
-            'combined' => array(
-                array(
+        $this->checker->check(vfsStream::url('root'), [
+            'combined' => [
+                [
                     'name' => 'test1',
-                    'package' => array(
-                        'composer' => array(
+                    'package' => [
+                        'composer' => [
                             'jadu/cms-dependencies' => '~13.6.0',
-                        ),
-                    ),
-                ),
-            ),
-        ));
+                        ],
+                    ],
+                ],
+            ],
+        ]);
     }
 
     /**
@@ -187,18 +187,18 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCheckThrowsExceptionWhenHasRequiredPackagesAndLockFileMissing()
     {
-        $this->checker->check(vfsStream::url('root'), array(
-            'combined' => array(
-                array(
+        $this->checker->check(vfsStream::url('root'), [
+            'combined' => [
+                [
                     'name' => 'test1',
-                    'package' => array(
-                        'composer' => array(
+                    'package' => [
+                        'composer' => [
                             'jadu/cms-dependencies' => '~13.6.0',
-                        ),
-                    ),
-                ),
-            ),
-        ));
+                        ],
+                    ],
+                ],
+            ],
+        ]);
     }
 
     /**
@@ -206,22 +206,22 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCheckThrowsExceptionWhenRequiredPackageMissingFromLockFile()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'composer.lock' => file_get_contents(__DIR__.'/Fixtures/composer.lock'),
-        ));
+        ]);
 
-        $this->checker->check(vfsStream::url('root'), array(
-            'combined' => array(
-                array(
+        $this->checker->check(vfsStream::url('root'), [
+            'combined' => [
+                [
                     'name' => 'test1',
-                    'package' => array(
-                        'composer' => array(
+                    'package' => [
+                        'composer' => [
                             'jadu/this-does-not-exist' => '~9.9.9',
-                        ),
-                    ),
-                ),
-            ),
-        ));
+                        ],
+                    ],
+                ],
+            ],
+        ]);
     }
 
     /**
@@ -229,21 +229,21 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCheckThrowsExceptionWhenVersionInLockFileDoesNotSatisfyRequiredPackageConstraint()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'composer.lock' => file_get_contents(__DIR__.'/Fixtures/composer.lock'),
-        ));
+        ]);
 
-        $this->checker->check(vfsStream::url('root'), array(
-            'combined' => array(
-                array(
+        $this->checker->check(vfsStream::url('root'), [
+            'combined' => [
+                [
                     'name' => 'test1',
-                    'package' => array(
-                        'composer' => array(
+                    'package' => [
+                        'composer' => [
                             'jadu/cms-dependencies' => '~14.6.0',
-                        ),
-                    ),
-                ),
-            ),
-        ));
+                        ],
+                    ],
+                ],
+            ],
+        ]);
     }
 }

--- a/tests/Package/Migrations/MigrationsCopierTest.php
+++ b/tests/Package/Migrations/MigrationsCopierTest.php
@@ -21,21 +21,21 @@ class MigrationsCopierTest extends \PHPUnit_Framework_TestCase
 
     public function testReturnsConfig()
     {
-        $config = array(
+        $config = [
             'name' => 'test',
-        );
+        ];
 
         $this->assertSame($config, $this->migrationsCopier->copy('working', 'temp', $config));
     }
 
     public function testCopiesMigrations()
     {
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'directory' => 'upgrades/migrations',
-            ),
-        );
+            ],
+        ];
 
         $this->filesystem->shouldReceive('copyDirectory')
             ->with('working/upgrades/migrations', 'temp/migrations/test')
@@ -46,20 +46,20 @@ class MigrationsCopierTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdatesMigrationsConfig()
     {
-        $config = array(
+        $config = [
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'directory' => 'upgrades/migrations',
-            ),
-        );
+            ],
+        ];
 
         $this->filesystem->shouldReceive('copyDirectory');
 
-        $this->assertSame(array(
+        $this->assertSame([
             'name' => 'test',
-            'migrations' => array(
+            'migrations' => [
                 'directory' => 'migrations/test',
-            ),
-        ), $this->migrationsCopier->copy('working', 'temp', $config));
+            ],
+        ], $this->migrationsCopier->copy('working', 'temp', $config));
     }
 }

--- a/tests/Package/PackageCreatorTest.php
+++ b/tests/Package/PackageCreatorTest.php
@@ -23,14 +23,14 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem');
         $this->packageArchiver = Mockery::mock('Meteor\Package\PackageArchiver');
-        $this->packageNameResolver = Mockery::mock('Meteor\Package\PackageNameResolver', array(
+        $this->packageNameResolver = Mockery::mock('Meteor\Package\PackageNameResolver', [
             'resolve' => 'package',
-        ));
+        ]);
         $this->migrationsCopier = Mockery::mock('Meteor\Package\Migrations\MigrationsCopier');
         $this->combinedPackageResolver = Mockery::mock('Meteor\Package\Combined\CombinedPackageResolver');
-        $this->composerDependencyChecker = Mockery::mock('Meteor\Package\Composer\ComposerDependencyChecker', array(
-            'getRequirements' => array(),
-        ));
+        $this->composerDependencyChecker = Mockery::mock('Meteor\Package\Composer\ComposerDependencyChecker', [
+            'getRequirements' => [],
+        ]);
         $this->configurationWriter = Mockery::mock('Meteor\Configuration\ConfigurationWriter');
         $this->io = new NullIO();
 
@@ -52,12 +52,12 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
         $outputDir = 'output';
         $tempDir = 'temp';
 
-        $config = array(
+        $config = [
             'name' => 'jadu/xfp',
-            'package' => array(
-                'combine' => array(),
-            ),
-        );
+            'package' => [
+                'combine' => [],
+            ],
+        ];
 
         $this->filesystem->shouldReceive('ensureDirectoryExists')
             ->andReturn($outputDir)
@@ -82,7 +82,7 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->combinedPackageResolver->shouldReceive('resolve')
-            ->with(array('cms.zip'), $outputDir, $tempDir, $config, false)
+            ->with(['cms.zip'], $outputDir, $tempDir, $config, false)
             ->andReturn($config)
             ->ordered()
             ->once();
@@ -107,7 +107,7 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             $outputDir,
             'package',
             $config,
-            array('cms.zip')
+            ['cms.zip']
         );
     }
 
@@ -117,12 +117,12 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
         $outputDir = 'output';
         $tempDir = 'temp';
 
-        $config = array(
+        $config = [
             'name' => 'jadu/xfp',
-            'package' => array(
-                'combine' => array(),
-            ),
-        );
+            'package' => [
+                'combine' => [],
+            ],
+        ];
 
         $this->filesystem->shouldReceive('ensureDirectoryExists')
             ->andReturn($outputDir)
@@ -169,7 +169,7 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             $outputDir,
             'package',
             $config,
-            array('cms.zip'),
+            ['cms.zip'],
             true
         );
     }
@@ -180,13 +180,13 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
         $outputDir = 'output';
         $tempDir = 'temp';
 
-        $config = array(
+        $config = [
             'name' => 'jadu/xfp',
-            'package' => array(
-                'files' => array('/**'),
-                'combine' => array(),
-            ),
-        );
+            'package' => [
+                'files' => ['/**'],
+                'combine' => [],
+            ],
+        ];
 
         $this->filesystem->shouldReceive('ensureDirectoryExists')
             ->andReturn($outputDir)
@@ -200,7 +200,7 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->filesystem->shouldReceive('copyDirectory')
-            ->with($workingDir, $tempDir.'/to_patch', array('/**'))
+            ->with($workingDir, $tempDir.'/to_patch', ['/**'])
             ->ordered()
             ->once();
 
@@ -210,9 +210,9 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             ->ordered()
             ->once();
 
-        $composerRequirements = array(
+        $composerRequirements = [
             new ComposerRequirement('jadu/cms-dependencies', '~13.6.0'),
-        );
+        ];
 
         $this->composerDependencyChecker->shouldReceive('getRequirements')
             ->with($workingDir)
@@ -220,7 +220,7 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->combinedPackageResolver->shouldReceive('resolve')
-            ->with(array('cms.zip'), $outputDir, $tempDir, $config, true)
+            ->with(['cms.zip'], $outputDir, $tempDir, $config, true)
             ->andReturn($config)
             ->ordered()
             ->once();
@@ -256,7 +256,7 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             $outputDir,
             'package',
             $config,
-            array('cms.zip')
+            ['cms.zip']
         );
     }
 
@@ -266,13 +266,13 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
         $outputDir = 'output';
         $tempDir = 'temp';
 
-        $config = array(
+        $config = [
             'name' => 'jadu/xfp',
-            'package' => array(
-                'files' => array('/**'),
-                'combine' => array(),
-            ),
-        );
+            'package' => [
+                'files' => ['/**'],
+                'combine' => [],
+            ],
+        ];
 
         $this->filesystem->shouldReceive('ensureDirectoryExists')
             ->andReturn($outputDir)
@@ -286,7 +286,7 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             ->once();
 
         $this->filesystem->shouldReceive('copyDirectory')
-            ->with($workingDir, $tempDir.'/to_patch', array('/**'))
+            ->with($workingDir, $tempDir.'/to_patch', ['/**'])
             ->ordered()
             ->once();
 
@@ -296,14 +296,14 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             ->ordered()
             ->once();
 
-        $composerRequirements = array();
+        $composerRequirements = [];
         $this->composerDependencyChecker->shouldReceive('getRequirements')
             ->with($workingDir)
             ->andReturn($composerRequirements)
             ->once();
 
         $this->combinedPackageResolver->shouldReceive('resolve')
-            ->with(array('cms.zip'), $outputDir, $tempDir, $config, false)
+            ->with(['cms.zip'], $outputDir, $tempDir, $config, false)
             ->andReturn($config)
             ->ordered()
             ->once();
@@ -333,7 +333,7 @@ class PackageCreatorTest extends \PHPUnit_Framework_TestCase
             $outputDir,
             'package',
             $config,
-            array('cms.zip'),
+            ['cms.zip'],
             false,
             'meteor.phar'
         );

--- a/tests/Package/PackageNameResolverTest.php
+++ b/tests/Package/PackageNameResolverTest.php
@@ -17,9 +17,9 @@ class PackageNameResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveReturnsFileNameWhenGiven()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/test',
-        );
+        ];
 
         $this->assertSame('package', $this->resolver->resolve('package', vfsStream::url('root'), $config));
     }
@@ -29,19 +29,19 @@ class PackageNameResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolveGeneratesFileNameFromPackageName($packageName, $expectedFileName)
     {
-        $config = array(
+        $config = [
             'name' => $packageName,
-        );
+        ];
 
         $this->assertSame($expectedFileName, $this->resolver->resolve(null, vfsStream::url('root'), $config));
     }
 
     public function packageNameProvider()
     {
-        return array(
-            array('jadu/test', 'jadu_test'),
-            array('XFP-3.9.1', 'XFP-3.9.1'),
-        );
+        return [
+            ['jadu/test', 'jadu_test'],
+            ['XFP-3.9.1', 'XFP-3.9.1'],
+        ];
     }
 
     /**
@@ -49,27 +49,27 @@ class PackageNameResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolveGeneratesFileNameFromPackageNameAndVersion($version, $expectedFileName)
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/test',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'VERSION' => $version,
-        ));
+        ]);
 
         $this->assertSame($expectedFileName, $this->resolver->resolve(null, vfsStream::url('root'), $config));
     }
 
     public function versionProvider()
     {
-        return array(
-            array('1.0.0', 'jadu_test_1.0.0'),
-            array('1.2.0-9298a2a08a460f2e3c16a71bb01d472af07137ba', 'jadu_test_1.2.0-9298a2a08a460f2e3c16a71bb01d472af07137ba'),
-            array('$$$$', 'jadu_test'),
-        );
+        return [
+            ['1.0.0', 'jadu_test_1.0.0'],
+            ['1.2.0-9298a2a08a460f2e3c16a71bb01d472af07137ba', 'jadu_test_1.2.0-9298a2a08a460f2e3c16a71bb01d472af07137ba'],
+            ['$$$$', 'jadu_test'],
+        ];
     }
 
     /**
@@ -77,12 +77,12 @@ class PackageNameResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolveThrowsExceptionWhenVersionFileCannotBeFound()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/test',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
         $this->resolver->resolve(null, vfsStream::url('root'), $config);
     }
@@ -92,21 +92,21 @@ class PackageNameResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolveGeneratesFileNameFromPackageNameWhenFileNameInvalid($fileName)
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/test',
-        );
+        ];
 
         $this->assertSame('jadu_test', $this->resolver->resolve($fileName, vfsStream::url('root'), $config));
     }
 
     public function invalidFileNameProvider()
     {
-        return array(
-            array(null),
-            array(''),
-            array('     '),
-            array('___'),
-            array('package$$$'),
-        );
+        return [
+            [null],
+            [''],
+            ['     '],
+            ['___'],
+            ['package$$$'],
+        ];
     }
 }

--- a/tests/Package/Provider/GoogleDrive/GoogleDrivePackageProviderTest.php
+++ b/tests/Package/Provider/GoogleDrive/GoogleDrivePackageProviderTest.php
@@ -15,9 +15,9 @@ class GoogleDrivePackageProviderTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->processRunner = Mockery::mock('Meteor\Process\ProcessRunner');
-        $this->packageProvider = new GoogleDrivePackageProvider($this->processRunner, new NullIO(), 'gdrive', array(
+        $this->packageProvider = new GoogleDrivePackageProvider($this->processRunner, new NullIO(), 'gdrive', [
             'jadu/cms' => '12345',
-        ));
+        ]);
 
         vfsStream::setup('root');
     }
@@ -25,9 +25,9 @@ class GoogleDrivePackageProviderTest extends \PHPUnit_Framework_TestCase
     public function testDownload()
     {
         // Create the file as if it was downloaded
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             '3.2.1.zip' => '',
-        ));
+        ]);
 
         $this->processRunner->shouldReceive('run')
             ->with("gdrive download query 'name = '\''3.2.1.zip'\'' and '\''12345'\'' in parents' --force", vfsStream::url('root'))

--- a/tests/Package/Provider/GoogleDrive/ServiceContainer/GoogleDrivePackageProviderExtensionTest.php
+++ b/tests/Package/Provider/GoogleDrive/ServiceContainer/GoogleDrivePackageProviderExtensionTest.php
@@ -8,11 +8,11 @@ class GoogleDrivePackageProviderExtensionTest extends ExtensionTestCase
 {
     public function testServicesLoadedWhenGDriveProvider()
     {
-        $container = $this->loadContainer(array(
-            'package' => array(
+        $container = $this->loadContainer([
+            'package' => [
                 'provider' => 'gdrive',
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertTrue($container->has('package.provider.gdrive'));
 
@@ -21,24 +21,24 @@ class GoogleDrivePackageProviderExtensionTest extends ExtensionTestCase
 
     public function testServicesNotLoadedWhenNotGDriveProvider()
     {
-        $container = $this->loadContainer(array(
-            'package' => array(
+        $container = $this->loadContainer([
+            'package' => [
                 'provider' => 'dummy',
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertFalse($container->has('package.provider.gdrive'));
     }
 
     public function testAddsDefaultFolders()
     {
-        $config = $this->processConfiguration(array());
+        $config = $this->processConfiguration([]);
 
-        $this->assertArraySubset(array(
-            'folders' => array(
+        $this->assertArraySubset([
+            'folders' => [
                 'jadu/cms' => '0B3tlQeNsllCKY2tzbFpUUkI2OGM',
                 'jadu/xfp' => '0B2h2-RgE2WidOHRhZVNUbUc1Z0E',
-            ),
-        ), $config['gdrive_package_provider']);
+            ],
+        ], $config['gdrive_package_provider']);
     }
 }

--- a/tests/Package/ServiceContainer/PackageExtensionTest.php
+++ b/tests/Package/ServiceContainer/PackageExtensionTest.php
@@ -8,7 +8,7 @@ class PackageExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,7 +17,7 @@ class PackageExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             PackageExtension::SERVICE_COMBINED_PACKAGE_DEPENDENCY_CHECKER,
             PackageExtension::SERVICE_COMBINED_PACKAGE_COMBINER,
             PackageExtension::SERVICE_COMBINED_PACKAGE_RESOLVER,
@@ -28,40 +28,40 @@ class PackageExtensionTest extends ExtensionTestCase
             PackageExtension::SERVICE_PACKAGE_CREATOR,
             PackageExtension::SERVICE_PACKAGE_EXTRACTOR,
             PackageExtension::SERVICE_PACKAGE_NAME_RESOLVER,
-        );
+        ];
     }
 
     public function testCombineConfigSectionCanHaveKeys()
     {
-        $config = $this->processConfiguration(array(
-            'package' => array(
-                'combine' => array(
+        $config = $this->processConfiguration([
+            'package' => [
+                'combine' => [
                     'jadu/cms' => '13.6.0',
                     'jadu/xfp' => '3.7.1',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
-        $this->assertSame(array(
+        $this->assertSame([
             'jadu/cms' => '13.6.0',
             'jadu/xfp' => '3.7.1',
-        ), $config['package']['combine']);
+        ], $config['package']['combine']);
     }
 
     public function testComposerConfigSectionCanHaveKeys()
     {
-        $config = $this->processConfiguration(array(
-            'package' => array(
-                'composer' => array(
+        $config = $this->processConfiguration([
+            'package' => [
+                'composer' => [
                     'jadu/cms-dependencies' => '~13.6.0',
                     'jadu/xfp-dependencies' => '~3.7.1',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
-        $this->assertSame(array(
+        $this->assertSame([
             'jadu/cms-dependencies' => '~13.6.0',
             'jadu/xfp-dependencies' => '~3.7.1',
-        ), $config['package']['composer']);
+        ], $config['package']['composer']);
     }
 }

--- a/tests/Patch/Backup/BackupFinderTest.php
+++ b/tests/Patch/Backup/BackupFinderTest.php
@@ -18,36 +18,36 @@ class BackupFinderTest extends \PHPUnit_Framework_TestCase
         $this->configurationLoader = Mockery::mock('Meteor\Configuration\ConfigurationLoader');
         $this->backupFinder = new BackupFinder(new VersionComparer(), $this->configurationLoader);
 
-        vfsStream::setup('root', null, array(
-            'backups' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'backups' => [],
+        ]);
     }
 
     public function testFind()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'backups' => array(
-                '20160701102030' => array(
-                    'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'backups' => [
+                '20160701102030' => [
+                    'to_patch' => [
                         'VERSION' => '1.0.0',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'VERSION' => '1.1.0',
-        ));
+        ]);
 
         $this->configurationLoader->shouldReceive('load')
             ->with(vfsStream::url('root/backups/20160701102030'))
-            ->andReturn(array(
+            ->andReturn([
                 'name' => 'jadu/cms',
-            ))
+            ])
             ->once();
 
         $backups = $this->backupFinder->find(vfsStream::url('root'), $config);
@@ -68,23 +68,23 @@ class BackupFinderTest extends \PHPUnit_Framework_TestCase
 
     public function testFindIgnoresBackupsWithoutMeteorConfig()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'backups' => array(
-                '20160701102030' => array(
-                    'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'backups' => [
+                '20160701102030' => [
+                    'to_patch' => [
                         'VERSION' => '1.0.0',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'VERSION' => '1.1.0',
-        ));
+        ]);
 
         $this->configurationLoader->shouldReceive('load')
             ->with(vfsStream::url('root/backups/20160701102030'))
@@ -98,23 +98,23 @@ class BackupFinderTest extends \PHPUnit_Framework_TestCase
 
     public function testFindIgnoresBackupsWithAnInvalidMeteorConfig()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'backups' => array(
-                '20160701102030' => array(
-                    'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'backups' => [
+                '20160701102030' => [
+                    'to_patch' => [
                         'VERSION' => '1.0.0',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'VERSION' => '1.1.0',
-        ));
+        ]);
 
         $this->configurationLoader->shouldReceive('load')
             ->with(vfsStream::url('root/backups/20160701102030'))
@@ -128,55 +128,55 @@ class BackupFinderTest extends \PHPUnit_Framework_TestCase
 
     public function testFindWithCombinedPackages()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'XFP_VERSION',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'jadu/cp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'CP_VERSION',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'backups' => array(
-                '20160701102030' => array(
-                    'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'backups' => [
+                '20160701102030' => [
+                    'to_patch' => [
                         'VERSION' => '1.0.0',
                         'XFP_VERSION' => '1.0.0',
                         'CP_VERSION' => '1.0.0',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'VERSION' => '1.1.0',
             'XFP_VERSION' => '1.1.0',
             'CP_VERSION' => '1.1.0',
-        ));
+        ]);
 
         $this->configurationLoader->shouldReceive('load')
             ->with(vfsStream::url('root/backups/20160701102030'))
-            ->andReturn(array(
+            ->andReturn([
                 'name' => 'jadu/cms',
-                'combined' => array(
-                    array(
+                'combined' => [
+                    [
                         'name' => 'jadu/cp',
-                    ),
-                    array(
+                    ],
+                    [
                         'name' => 'jadu/xfp',
-                    ),
-                ),
-            ))
+                    ],
+                ],
+            ])
             ->once();
 
         $backups = $this->backupFinder->find(vfsStream::url('root'), $config);
@@ -208,55 +208,55 @@ class BackupFinderTest extends \PHPUnit_Framework_TestCase
 
     public function testFindWithDifferentCombinedPackages()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'XFP_VERSION',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'jadu/cp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'CP_VERSION',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'backups' => array(
-                '20160701102030' => array(
-                    'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'backups' => [
+                '20160701102030' => [
+                    'to_patch' => [
                         'VERSION' => '1.0.0',
                         'XFP_VERSION' => '1.0.0',
                         'CP_VERSION' => '1.0.0',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'VERSION' => '1.1.0',
             'XFP_VERSION' => '1.1.0',
             'CP_VERSION' => '1.1.0',
-        ));
+        ]);
 
         $this->configurationLoader->shouldReceive('load')
             ->with(vfsStream::url('root/backups/20160701102030'))
-            ->andReturn(array(
+            ->andReturn([
                 'name' => 'jadu/cms',
-                'combined' => array(
-                    array(
+                'combined' => [
+                    [
                         'name' => 'jadu/xfp',
-                    ),
-                    array(
+                    ],
+                    [
                         'name' => 'jadu/poo',
-                    ),
-                ),
-            ))
+                    ],
+                ],
+            ])
             ->once();
 
         $backups = $this->backupFinder->find(vfsStream::url('root'), $config);
@@ -266,29 +266,29 @@ class BackupFinderTest extends \PHPUnit_Framework_TestCase
 
     public function testFindWhenBackupHasDifferentPackages()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'backups' => array(
-                '20160701102030' => array(
-                    'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'backups' => [
+                '20160701102030' => [
+                    'to_patch' => [
                         'VERSION' => '1.0.0',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'VERSION' => '1.1.0',
-        ));
+        ]);
 
         $this->configurationLoader->shouldReceive('load')
             ->with(vfsStream::url('root/backups/20160701102030'))
-            ->andReturn(array(
+            ->andReturn([
                 'name' => 'jadu/xfp',
-            ))
+            ])
             ->once();
 
         $backups = $this->backupFinder->find(vfsStream::url('root'), $config);
@@ -298,29 +298,29 @@ class BackupFinderTest extends \PHPUnit_Framework_TestCase
 
     public function testFindWhenBackupIsNewerThanInstall()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        vfsStream::setup('root', null, array(
-            'backups' => array(
-                '20160701102030' => array(
-                    'to_patch' => array(
+        vfsStream::setup('root', null, [
+            'backups' => [
+                '20160701102030' => [
+                    'to_patch' => [
                         'VERSION' => '1.1.0',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'VERSION' => '1.0.0',
-        ));
+        ]);
 
         $this->configurationLoader->shouldReceive('load')
             ->with(vfsStream::url('root/backups/20160701102030'))
-            ->andReturn(array(
+            ->andReturn([
                 'name' => 'jadu/cms',
-            ))
+            ])
             ->once();
 
         $backups = $this->backupFinder->find(vfsStream::url('root'), $config);

--- a/tests/Patch/Backup/BackupTest.php
+++ b/tests/Patch/Backup/BackupTest.php
@@ -6,7 +6,7 @@ class BackupTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetDate()
     {
-        $backup = new Backup('/path/to/20160203145217', array());
+        $backup = new Backup('/path/to/20160203145217', []);
 
         $this->assertSame('2016-02-03T14:52:17+00:00', $backup->getDate()->format('c'));
     }

--- a/tests/Patch/Cli/Command/ApplyCommandTest.php
+++ b/tests/Patch/Cli/Command/ApplyCommandTest.php
@@ -20,23 +20,23 @@ class ApplyCommandTest extends CommandTestCase
 
     public function createCommand()
     {
-        vfsStream::setup('root', null, array(
-            'patch' => array(),
-            'install' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'patch' => [],
+            'install' => [],
+        ]);
 
         $this->taskBus = Mockery::mock('Meteor\Patch\Task\TaskBusInterface');
         $this->strategy = Mockery::mock('Meteor\Patch\Strategy\PatchStrategyInterface');
-        $this->platform = Mockery::mock('Meteor\Platform\PlatformInterface', array(
+        $this->platform = Mockery::mock('Meteor\Platform\PlatformInterface', [
             'setInstallDir' => null,
-        ));
+        ]);
         $this->locker = Mockery::mock('Meteor\Patch\Lock\Locker');
-        $this->eventDispatcher = Mockery::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface', array(
+        $this->eventDispatcher = Mockery::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface', [
             'dispatch' => null,
-        ));
-        $this->scriptRunner = Mockery::mock('Meteor\Scripts\ScriptRunner', array(
+        ]);
+        $this->scriptRunner = Mockery::mock('Meteor\Scripts\ScriptRunner', [
             'setWorkingDir' => null,
-        ));
+        ]);
         $this->logger = Mockery::mock('Meteor\Logger\LoggerInterface');
 
         $this->strategy->shouldReceive('configureApplyCommand')
@@ -44,7 +44,7 @@ class ApplyCommandTest extends CommandTestCase
 
         return new ApplyCommand(
             null,
-            array(),
+            [],
             new NullIO(),
             $this->platform,
             $this->taskBus,
@@ -61,7 +61,7 @@ class ApplyCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
         $this->command->setConfiguration($config);
 
         $this->platform->shouldReceive('setInstallDir')
@@ -83,10 +83,10 @@ class ApplyCommandTest extends CommandTestCase
             ->with(PatchEvents::PRE_APPLY, Mockery::any())
             ->once();
 
-        $tasks = array(
+        $tasks = [
             new \stdClass(),
             new \stdClass(),
-        );
+        ];
         $this->strategy->shouldReceive('apply')
             ->with($workingDir, $installDir, Mockery::any())
             ->andReturn($tasks)
@@ -110,10 +110,10 @@ class ApplyCommandTest extends CommandTestCase
             ->with($installDir)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 
     /**
@@ -124,10 +124,10 @@ class ApplyCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/install');
         $installDir = vfsStream::url('root/install');
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 
     public function testDoesNotLockWhenSkipLockOptionSpecified()
@@ -135,7 +135,7 @@ class ApplyCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
         $this->command->setConfiguration($config);
 
         $this->logger->shouldReceive('enable')
@@ -144,7 +144,7 @@ class ApplyCommandTest extends CommandTestCase
         $this->locker->shouldReceive('lock')
             ->never();
 
-        $tasks = array(new \stdClass());
+        $tasks = [new \stdClass()];
         $this->strategy->shouldReceive('apply')
             ->with($workingDir, $installDir, Mockery::any())
             ->andReturn($tasks)
@@ -158,11 +158,11 @@ class ApplyCommandTest extends CommandTestCase
         $this->locker->shouldReceive('unlock')
             ->never();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
             '--skip-lock' => null,
-        ));
+        ]);
     }
 
     public function testDoesNotUnlockIfTaskFails()
@@ -170,7 +170,7 @@ class ApplyCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
         $this->command->setConfiguration($config);
 
         $this->logger->shouldReceive('enable')
@@ -180,7 +180,7 @@ class ApplyCommandTest extends CommandTestCase
             ->with($installDir)
             ->once();
 
-        $tasks = array(new \stdClass());
+        $tasks = [new \stdClass()];
         $this->strategy->shouldReceive('apply')
             ->with($workingDir, $installDir, Mockery::any())
             ->andReturn($tasks)
@@ -194,10 +194,10 @@ class ApplyCommandTest extends CommandTestCase
         $this->locker->shouldReceive('unlock')
             ->never();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 
     /**
@@ -209,20 +209,20 @@ class ApplyCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'package' => array(
+            'package' => [
                 'php' => '>=7',
-            ),
-        );
+            ],
+        ];
 
         $this->command->setConfiguration($config);
         $this->command->setPhpVersion('5.6.0');
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 
     /**
@@ -234,34 +234,34 @@ class ApplyCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array(
+        $config = [
             'name' => 'test',
-            'package' => array(
+            'package' => [
                 'php' => '>=5.3.3',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'package/first',
-                    'package' => array(
+                    'package' => [
                         'php' => '>=5.4.0',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'package/second',
-                    'package' => array(
+                    'package' => [
                         'php' => '>=5.6',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->command->setConfiguration($config);
         $this->command->setPhpVersion('5.4.0');
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 
     public function testDoesNotRunScriptsIfSkipped()
@@ -269,7 +269,7 @@ class ApplyCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
         $this->command->setConfiguration($config);
 
         $this->platform->shouldReceive('setInstallDir')
@@ -287,10 +287,10 @@ class ApplyCommandTest extends CommandTestCase
             ->with(PatchEvents::PRE_APPLY, Mockery::any())
             ->never();
 
-        $tasks = array(
+        $tasks = [
             new \stdClass(),
             new \stdClass(),
-        );
+        ];
         $this->strategy->shouldReceive('apply')
             ->with($workingDir, $installDir, Mockery::any())
             ->andReturn($tasks);
@@ -310,10 +310,10 @@ class ApplyCommandTest extends CommandTestCase
         $this->locker->shouldReceive('unlock')
             ->with($installDir);
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
             '--skip-scripts' => null,
-        ));
+        ]);
     }
 }

--- a/tests/Patch/Cli/Command/ClearLockCommandTest.php
+++ b/tests/Patch/Cli/Command/ClearLockCommandTest.php
@@ -17,7 +17,7 @@ class ClearLockCommandTest extends CommandTestCase
         $this->platform = Mockery::mock('Meteor\Platform\PlatformInterface');
         $this->locker = Mockery::mock('Meteor\Patch\Lock\Locker');
 
-        return new ClearLockCommand(null, array(), new NullIO(), $this->platform, $this->locker);
+        return new ClearLockCommand(null, [], new NullIO(), $this->platform, $this->locker);
     }
 
     public function testUnlocksInstall()
@@ -28,8 +28,8 @@ class ClearLockCommandTest extends CommandTestCase
             ->with($installDir)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 }

--- a/tests/Patch/Cli/Command/RollbackCommandTest.php
+++ b/tests/Patch/Cli/Command/RollbackCommandTest.php
@@ -23,25 +23,25 @@ class RollbackCommandTest extends CommandTestCase
 
     public function createCommand()
     {
-        vfsStream::setup('root', null, array(
-            'patch' => array(),
-            'install' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'patch' => [],
+            'install' => [],
+        ]);
 
         $this->versionComparer = Mockery::mock('Meteor\Patch\Version\VersionComparer');
         $this->backupFinder = Mockery::mock('Meteor\Patch\Backup\BackupFinder');
         $this->taskBus = Mockery::mock('Meteor\Patch\Task\TaskBusInterface');
         $this->strategy = Mockery::mock('Meteor\Patch\Strategy\PatchStrategyInterface');
-        $this->platform = Mockery::mock('Meteor\Platform\PlatformInterface', array(
+        $this->platform = Mockery::mock('Meteor\Platform\PlatformInterface', [
             'setInstallDir' => null,
-        ));
+        ]);
         $this->locker = Mockery::mock('Meteor\Patch\Lock\Locker');
-        $this->eventDispatcher = Mockery::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface', array(
+        $this->eventDispatcher = Mockery::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface', [
             'dispatch' => null,
-        ));
-        $this->scriptRunner = Mockery::mock('Meteor\Scripts\ScriptRunner', array(
+        ]);
+        $this->scriptRunner = Mockery::mock('Meteor\Scripts\ScriptRunner', [
             'setWorkingDir' => null,
-        ));
+        ]);
         $this->logger = Mockery::mock('Meteor\Logger\LoggerInterface');
 
         $this->strategy->shouldReceive('configureRollbackCommand')
@@ -49,7 +49,7 @@ class RollbackCommandTest extends CommandTestCase
 
         return new RollbackCommand(
             null,
-            array(),
+            [],
             new NullIO(),
             $this->platform,
             $this->versionComparer,
@@ -68,7 +68,7 @@ class RollbackCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
         $this->command->setConfiguration($config);
 
         $this->platform->shouldReceive('setInstallDir')
@@ -81,14 +81,14 @@ class RollbackCommandTest extends CommandTestCase
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with($workingDir.'/to_patch', $installDir, $config)
-            ->andReturn(array())
+            ->andReturn([])
             ->once();
 
-        $backups = array(
-            new Backup(vfsStream::url('root/install/backups/20160701102030'), array()),
-            new Backup(vfsStream::url('root/install/backups/20160702102030'), array()),
-            new Backup(vfsStream::url('root/install/backups/20160703102030'), array()),
-        );
+        $backups = [
+            new Backup(vfsStream::url('root/install/backups/20160701102030'), []),
+            new Backup(vfsStream::url('root/install/backups/20160702102030'), []),
+            new Backup(vfsStream::url('root/install/backups/20160703102030'), []),
+        ];
 
         $this->backupFinder->shouldReceive('find')
             ->with($installDir, $config)
@@ -108,12 +108,12 @@ class RollbackCommandTest extends CommandTestCase
             ->with(PatchEvents::PRE_ROLLBACK, Mockery::any())
             ->once();
 
-        $tasks = array(
+        $tasks = [
             new \stdClass(),
             new \stdClass(),
-        );
+        ];
         $this->strategy->shouldReceive('rollback')
-            ->with($backupDir, $workingDir, $installDir, array(), Mockery::any())
+            ->with($backupDir, $workingDir, $installDir, [], Mockery::any())
             ->andReturn($tasks)
             ->once();
 
@@ -135,10 +135,10 @@ class RollbackCommandTest extends CommandTestCase
             ->with($installDir)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 
     public function testDoesNotRunScriptsIfSkipped()
@@ -146,7 +146,7 @@ class RollbackCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
         $this->command->setConfiguration($config);
 
         $this->platform->shouldReceive('setInstallDir')
@@ -157,13 +157,13 @@ class RollbackCommandTest extends CommandTestCase
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with($workingDir.'/to_patch', $installDir, $config)
-            ->andReturn(array());
+            ->andReturn([]);
 
-        $backups = array(
-            new Backup(vfsStream::url('root/install/backups/20160701102030'), array()),
-            new Backup(vfsStream::url('root/install/backups/20160702102030'), array()),
-            new Backup(vfsStream::url('root/install/backups/20160703102030'), array()),
-        );
+        $backups = [
+            new Backup(vfsStream::url('root/install/backups/20160701102030'), []),
+            new Backup(vfsStream::url('root/install/backups/20160702102030'), []),
+            new Backup(vfsStream::url('root/install/backups/20160703102030'), []),
+        ];
 
         $this->backupFinder->shouldReceive('find')
             ->with($installDir, $config)
@@ -180,12 +180,12 @@ class RollbackCommandTest extends CommandTestCase
             ->with(PatchEvents::PRE_ROLLBACK, Mockery::any())
             ->never();
 
-        $tasks = array(
+        $tasks = [
             new \stdClass(),
             new \stdClass(),
-        );
+        ];
         $this->strategy->shouldReceive('rollback')
-            ->with($backupDir, $workingDir, $installDir, array(), Mockery::any())
+            ->with($backupDir, $workingDir, $installDir, [], Mockery::any())
             ->andReturn($tasks);
 
         $this->taskBus->shouldReceive('run')
@@ -203,11 +203,11 @@ class RollbackCommandTest extends CommandTestCase
         $this->locker->shouldReceive('unlock')
             ->with($installDir);
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
             '--skip-scripts' => null,
-        ));
+        ]);
     }
 
     /**
@@ -218,10 +218,10 @@ class RollbackCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/install');
         $installDir = vfsStream::url('root/install');
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 
     public function testDoesNotLockWhenSkipLockOptionSpecified()
@@ -229,19 +229,19 @@ class RollbackCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
         $this->command->setConfiguration($config);
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with($workingDir.'/to_patch', $installDir, $config)
-            ->andReturn(array())
+            ->andReturn([])
             ->once();
 
-        $backups = array(
-            new Backup(vfsStream::url('root/install/backups/20160701102030'), array()),
-            new Backup(vfsStream::url('root/install/backups/20160702102030'), array()),
-            new Backup(vfsStream::url('root/install/backups/20160703102030'), array()),
-        );
+        $backups = [
+            new Backup(vfsStream::url('root/install/backups/20160701102030'), []),
+            new Backup(vfsStream::url('root/install/backups/20160702102030'), []),
+            new Backup(vfsStream::url('root/install/backups/20160703102030'), []),
+        ];
 
         $this->backupFinder->shouldReceive('find')
             ->with($installDir, $config)
@@ -256,9 +256,9 @@ class RollbackCommandTest extends CommandTestCase
         $this->locker->shouldReceive('lock')
             ->never();
 
-        $tasks = array(new \stdClass());
+        $tasks = [new \stdClass()];
         $this->strategy->shouldReceive('rollback')
-            ->with($backupDir, $workingDir, $installDir, array(), Mockery::any())
+            ->with($backupDir, $workingDir, $installDir, [], Mockery::any())
             ->andReturn($tasks)
             ->once();
 
@@ -270,11 +270,11 @@ class RollbackCommandTest extends CommandTestCase
         $this->locker->shouldReceive('unlock')
             ->never();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
             '--skip-lock' => null,
-        ));
+        ]);
     }
 
     public function testDoesNotUnlockIfTaskFails()
@@ -282,19 +282,19 @@ class RollbackCommandTest extends CommandTestCase
         $workingDir = vfsStream::url('root/patch');
         $installDir = vfsStream::url('root/install');
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
         $this->command->setConfiguration($config);
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with($workingDir.'/to_patch', $installDir, $config)
-            ->andReturn(array())
+            ->andReturn([])
             ->once();
 
-        $backups = array(
-            new Backup(vfsStream::url('root/install/backups/20160701102030'), array()),
-            new Backup(vfsStream::url('root/install/backups/20160702102030'), array()),
-            new Backup(vfsStream::url('root/install/backups/20160703102030'), array()),
-        );
+        $backups = [
+            new Backup(vfsStream::url('root/install/backups/20160701102030'), []),
+            new Backup(vfsStream::url('root/install/backups/20160702102030'), []),
+            new Backup(vfsStream::url('root/install/backups/20160703102030'), []),
+        ];
 
         $this->backupFinder->shouldReceive('find')
             ->with($installDir, $config)
@@ -310,9 +310,9 @@ class RollbackCommandTest extends CommandTestCase
             ->with($installDir)
             ->once();
 
-        $tasks = array(new \stdClass());
+        $tasks = [new \stdClass()];
         $this->strategy->shouldReceive('rollback')
-            ->with($backupDir, $workingDir, $installDir, array(), Mockery::any())
+            ->with($backupDir, $workingDir, $installDir, [], Mockery::any())
             ->andReturn($tasks)
             ->once();
 
@@ -324,9 +324,9 @@ class RollbackCommandTest extends CommandTestCase
         $this->locker->shouldReceive('unlock')
             ->never();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 }

--- a/tests/Patch/Cli/Command/VersionInfoCommandTest.php
+++ b/tests/Patch/Cli/Command/VersionInfoCommandTest.php
@@ -15,15 +15,15 @@ class VersionInfoCommandTest extends CommandTestCase
 
     public function createCommand()
     {
-        vfsStream::setup('root', null, array(
-            'patch' => array(),
-            'install' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'patch' => [],
+            'install' => [],
+        ]);
 
         $this->platform = Mockery::mock('Meteor\Platform\PlatformInterface');
         $this->taskBus = Mockery::mock('Meteor\Patch\Task\TaskBusInterface');
 
-        return new VersionInfoCommand(null, array('name' => 'test'), new NullIO(), $this->platform, $this->taskBus);
+        return new VersionInfoCommand(null, ['name' => 'test'], new NullIO(), $this->platform, $this->taskBus);
     }
 
     public function testRunsDisplayVersionInfoTask()
@@ -40,13 +40,13 @@ class VersionInfoCommandTest extends CommandTestCase
 
                     return true;
                 }),
-                array('name' => 'test')
+                ['name' => 'test']
             )
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             '--working-dir' => $workingDir,
             '--install-dir' => $installDir,
-        ));
+        ]);
     }
 }

--- a/tests/Patch/ServiceContainer/PatchExtensionTest.php
+++ b/tests/Patch/ServiceContainer/PatchExtensionTest.php
@@ -8,7 +8,7 @@ class PatchExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,7 +17,7 @@ class PatchExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             PatchExtension::SERVICE_COMMAND_APPLY,
             PatchExtension::SERVICE_COMMAND_CLEAR_LOCK,
             PatchExtension::SERVICE_COMMAND_ROLLBACK,
@@ -37,6 +37,6 @@ class PatchExtensionTest extends ExtensionTestCase
             PatchExtension::SERVICE_TASK_MIGRATE_UP_HANDLER,
             PatchExtension::SERVICE_TASK_UPDATE_MIGRATION_VERSION_FILES_HANDLER,
             PatchExtension::SERVICE_VERSION_COMPARER,
-        );
+        ];
     }
 }

--- a/tests/Patch/Strategy/Overwrite/OverwritePatchStrategyTest.php
+++ b/tests/Patch/Strategy/Overwrite/OverwritePatchStrategyTest.php
@@ -16,12 +16,12 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testApply()
     {
-        $tasks = $this->strategy->apply('patch', 'install', array(
+        $tasks = $this->strategy->apply('patch', 'install', [
             'skip-backup' => false,
             'skip-db-migrations' => false,
             'skip-file-migrations' => false,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertSame('install', $tasks[0]->targetDir);
@@ -72,12 +72,12 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyCanSkipVersionCheck()
     {
-        $tasks = $this->strategy->apply('patch', 'install', array(
+        $tasks = $this->strategy->apply('patch', 'install', [
             'skip-backup' => false,
             'skip-db-migrations' => false,
             'skip-file-migrations' => false,
             'skip-version-check' => true,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
@@ -92,12 +92,12 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyCanSkipFileMigrations()
     {
-        $tasks = $this->strategy->apply('patch', 'install', array(
+        $tasks = $this->strategy->apply('patch', 'install', [
             'skip-backup' => false,
             'skip-db-migrations' => false,
             'skip-file-migrations' => true,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
@@ -113,12 +113,12 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyCanSkipDbMigrations()
     {
-        $tasks = $this->strategy->apply('patch', 'install', array(
+        $tasks = $this->strategy->apply('patch', 'install', [
             'skip-backup' => false,
             'skip-db-migrations' => true,
             'skip-file-migrations' => false,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
@@ -134,12 +134,12 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyCanSkipDbAndFileMigrations()
     {
-        $tasks = $this->strategy->apply('patch', 'install', array(
+        $tasks = $this->strategy->apply('patch', 'install', [
             'skip-backup' => false,
             'skip-db-migrations' => true,
             'skip-file-migrations' => true,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
@@ -153,12 +153,12 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyCanSkipBackup()
     {
-        $tasks = $this->strategy->apply('patch', 'install', array(
+        $tasks = $this->strategy->apply('patch', 'install', [
             'skip-backup' => true,
             'skip-db-migrations' => false,
             'skip-file-migrations' => false,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
@@ -173,11 +173,11 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testRollback()
     {
-        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', array(), array(
+        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', [], [
             'skip-db-migrations' => false,
             'skip-file-migrations' => false,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertSame('install', $tasks[0]->targetDir);
@@ -216,11 +216,11 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testRollbackCanSkipDbMigrations()
     {
-        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', array(), array(
+        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', [], [
             'skip-db-migrations' => true,
             'skip-file-migrations' => false,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
@@ -233,11 +233,11 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testRollbackCanSkipFileMigrations()
     {
-        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', array(), array(
+        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', [], [
             'skip-db-migrations' => false,
             'skip-file-migrations' => true,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
@@ -250,11 +250,11 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testRollbackCanSkipDbAndFileMigrations()
     {
-        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', array(), array(
+        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', [], [
             'skip-db-migrations' => true,
             'skip-file-migrations' => true,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
@@ -265,11 +265,11 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testRollbackCanSkipVersionCheck()
     {
-        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', array(), array(
+        $tasks = $this->strategy->rollback('backups/1', 'patch', 'install', [], [
             'skip-db-migrations' => false,
             'skip-file-migrations' => false,
             'skip-version-check' => true,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\CheckWritePermission', $tasks[0]);
         $this->assertInstanceOf('Meteor\Patch\Task\DisplayVersionInfo', $tasks[1]);
@@ -282,11 +282,11 @@ class OverwritePatchStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testRollbackDeletesIntermediateBackups()
     {
-        $tasks = $this->strategy->rollback('backups/3', 'patch', 'install', array('backups/1', 'backups/2'), array(
+        $tasks = $this->strategy->rollback('backups/3', 'patch', 'install', ['backups/1', 'backups/2'], [
             'skip-db-migrations' => false,
             'skip-file-migrations' => false,
             'skip-version-check' => false,
-        ));
+        ]);
 
         $this->assertInstanceOf('Meteor\Patch\Task\DeleteBackup', $tasks[7]);
         $this->assertSame('backups/1', $tasks[7]->backupDir);

--- a/tests/Patch/Strategy/Overwrite/ServiceContainer/OverwritePatchStrategyExtensionTest.php
+++ b/tests/Patch/Strategy/Overwrite/ServiceContainer/OverwritePatchStrategyExtensionTest.php
@@ -8,22 +8,22 @@ class OverwritePatchStrategyExtensionTest extends ExtensionTestCase
 {
     public function testServicesLoadedWhenOverwriteStrategy()
     {
-        $container = $this->loadContainer(array(
-            'patch' => array(
+        $container = $this->loadContainer([
+            'patch' => [
                 'strategy' => 'overwrite',
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertTrue($container->has('patch.strategy.overwrite'));
     }
 
     public function testServicesNotLoadedWhenNotOverwriteStrategy()
     {
-        $container = $this->loadContainer(array(
-            'patch' => array(
+        $container = $this->loadContainer([
+            'patch' => [
                 'strategy' => 'dummy',
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertFalse($container->has('patch.strategy.overwrite'));
     }

--- a/tests/Patch/Task/BackupFilesHandlerTest.php
+++ b/tests/Patch/Task/BackupFilesHandlerTest.php
@@ -14,15 +14,15 @@ class BackupFilesHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem', array(
+        $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem', [
             'ensureDirectoryExists' => null,
-            'findFiles' => array(),
+            'findFiles' => [],
             'copyFiles' => null,
             'copy' => null,
-        ));
-        $this->configurationLoader = Mockery::mock('Meteor\Configuration\configurationLoader', array(
+        ]);
+        $this->configurationLoader = Mockery::mock('Meteor\Configuration\configurationLoader', [
             'resolve' => null,
-        ));
+        ]);
         $this->io = new NullIO();
 
         $this->handler = new BackupFilesHandler($this->filesystem, $this->configurationLoader, $this->io);
@@ -30,7 +30,7 @@ class BackupFilesHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testCopiesFilesFromInstallIntoBackupDirectory()
     {
-        $patchFiles = array('VERSION');
+        $patchFiles = ['VERSION'];
         $this->filesystem->shouldReceive('findFiles')
             ->with('patch/to_patch')
             ->andReturn($patchFiles)
@@ -40,7 +40,7 @@ class BackupFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->with($patchFiles, 'install', 'install/backups/20160701000000/to_patch')
             ->once();
 
-        $this->handler->handle(new BackupFiles('install/backups/20160701000000', 'patch', 'install'), array());
+        $this->handler->handle(new BackupFiles('install/backups/20160701000000', 'patch', 'install'), []);
     }
 
     public function testCopiesMeteorConfigIntoBackupFromPatch()
@@ -54,6 +54,6 @@ class BackupFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->with('patch/meteor.json.package', 'install/backups/20160701000000/meteor.json.package', true)
             ->once();
 
-        $this->handler->handle(new BackupFiles('install/backups/20160701000000', 'patch', 'install'), array());
+        $this->handler->handle(new BackupFiles('install/backups/20160701000000', 'patch', 'install'), []);
     }
 }

--- a/tests/Patch/Task/CheckDatabaseConnectionHandlerTest.php
+++ b/tests/Patch/Task/CheckDatabaseConnectionHandlerTest.php
@@ -17,12 +17,12 @@ class CheckDatabaseConnectionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testChecksConnectionWhenRootPackageHasMigrations()
     {
-        $config = array(
-            'migrations' => array(
+        $config = [
+            'migrations' => [
                 'table' => 'migrations',
-            ),
-            'combined' => array(),
-        );
+            ],
+            'combined' => [],
+        ];
 
         $this->connectionFactory->shouldReceive('getConnection')
             ->with('install')
@@ -34,15 +34,15 @@ class CheckDatabaseConnectionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testChecksConnectionWhenCombinedPackagesHaveMigrations()
     {
-        $config = array(
-            'combined' => array(
-                array(
-                    'migrations' => array(
+        $config = [
+            'combined' => [
+                [
+                    'migrations' => [
                         'table' => 'migrations',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->connectionFactory->shouldReceive('getConnection')
             ->with('install')
@@ -54,9 +54,9 @@ class CheckDatabaseConnectionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testDoesNotCheckConnectionIfNoMigrations()
     {
-        $config = array(
-            'combined' => array(),
-        );
+        $config = [
+            'combined' => [],
+        ];
 
         $this->connectionFactory->shouldReceive('getConnection')
             ->never();

--- a/tests/Patch/Task/CheckDiskSpaceHandlerTest.php
+++ b/tests/Patch/Task/CheckDiskSpaceHandlerTest.php
@@ -27,7 +27,7 @@ class CheckDiskSpaceHandlerTest extends \PHPUnit_Framework_TestCase
         $GLOBALS['disk_total_space'] = 1048576000;
         $GLOBALS['disk_free_space'] = 1048576000;
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
         $this->assertTrue($this->handler->handle(new CheckDiskSpace('install'), $config));
     }
 
@@ -36,11 +36,11 @@ class CheckDiskSpaceHandlerTest extends \PHPUnit_Framework_TestCase
         $GLOBALS['disk_total_space'] = 1048576000;
         $GLOBALS['disk_free_space'] = 419430400;
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
 
         $this->backupFinder->shouldReceive('find')
             ->with('install', $config)
-            ->andReturn(array());
+            ->andReturn([]);
 
         $this->assertFalse($this->handler->handle(new CheckDiskSpace('install'), $config));
     }
@@ -50,15 +50,15 @@ class CheckDiskSpaceHandlerTest extends \PHPUnit_Framework_TestCase
         $GLOBALS['disk_total_space'] = 1048576000;
         $GLOBALS['disk_free_space'] = 419430400;
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
 
-        $backups = array(
-            new Backup('backups/5', array()),
-            new Backup('backups/4', array()),
-            new Backup('backups/3', array()),
-            new Backup('backups/2', array()),
-            new Backup('backups/1', array()),
-        );
+        $backups = [
+            new Backup('backups/5', []),
+            new Backup('backups/4', []),
+            new Backup('backups/3', []),
+            new Backup('backups/2', []),
+            new Backup('backups/1', []),
+        ];
 
         $this->backupFinder->shouldReceive('find')
             ->with('install', $config)
@@ -97,12 +97,12 @@ class CheckDiskSpaceHandlerTest extends \PHPUnit_Framework_TestCase
         $GLOBALS['disk_total_space'] = 1048576000;
         $GLOBALS['disk_free_space'] = 419430400;
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
 
-        $backups = array(
-            new Backup('backups/5', array()),
-            new Backup('backups/4', array()),
-        );
+        $backups = [
+            new Backup('backups/5', []),
+            new Backup('backups/4', []),
+        ];
 
         $this->backupFinder->shouldReceive('find')
             ->with('install', $config)
@@ -120,15 +120,15 @@ class CheckDiskSpaceHandlerTest extends \PHPUnit_Framework_TestCase
         $GLOBALS['disk_total_space'] = 1048576000;
         $GLOBALS['disk_free_space'] = 104857600;
 
-        $config = array('name' => 'test');
+        $config = ['name' => 'test'];
 
-        $backups = array(
-            new Backup('backups/5', array()),
-            new Backup('backups/4', array()),
-            new Backup('backups/3', array()),
-            new Backup('backups/2', array()),
-            new Backup('backups/1', array()),
-        );
+        $backups = [
+            new Backup('backups/5', []),
+            new Backup('backups/4', []),
+            new Backup('backups/3', []),
+            new Backup('backups/2', []),
+            new Backup('backups/1', []),
+        ];
 
         $this->backupFinder->shouldReceive('find')
             ->with('install', $config)

--- a/tests/Patch/Task/CheckModuleCmsDependencyHandlerTest.php
+++ b/tests/Patch/Task/CheckModuleCmsDependencyHandlerTest.php
@@ -19,14 +19,14 @@ class CheckModuleCmsDependencyHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testChecksWorkingDirVersionAndInstallDoesntHaveVersion($moduleCmsDependency, $version, $expectedResult)
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(
+        vfsStream::setup('root', null, [
+            'working' => [
                 'MODULE_CMS_DEPENDENCY' => $moduleCmsDependency,
                 'VERSION' => $version,
-            ),
-            'install' => array(
-            ),
-        ));
+            ],
+            'install' => [
+            ],
+        ]);
 
         $task = new CheckModuleCmsDependency(vfsStream::url('root/working'), vfsStream::url('root/install'));
         $this->assertSame($expectedResult, $this->handler->handle($task));
@@ -37,15 +37,15 @@ class CheckModuleCmsDependencyHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testChecksWorkingDirVersionA($moduleCmsDependency, $version, $expectedResult)
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(
+        vfsStream::setup('root', null, [
+            'working' => [
                 'MODULE_CMS_DEPENDENCY' => $moduleCmsDependency,
                 'VERSION' => $version,
-            ),
-            'install' => array(
+            ],
+            'install' => [
                 'VERSION' => '1.0.0',
-            ),
-        ));
+            ],
+        ]);
 
         $task = new CheckModuleCmsDependency(vfsStream::url('root/working'), vfsStream::url('root/install'));
         $this->assertSame($expectedResult, $this->handler->handle($task));
@@ -53,10 +53,10 @@ class CheckModuleCmsDependencyHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testReturnsTrueIfModuleCmsDependencyFileNotFoundInWorkingDir()
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(),
-            'install' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'working' => [],
+            'install' => [],
+        ]);
 
         $task = new CheckModuleCmsDependency(vfsStream::url('root/working'), vfsStream::url('root/install'));
         $this->assertTrue($this->handler->handle($task));
@@ -64,12 +64,12 @@ class CheckModuleCmsDependencyHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testReturnsTrueIfCmsVersionFileNotFoundInInstallDir()
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(
+        vfsStream::setup('root', null, [
+            'working' => [
                 'MODULE_CMS_DEPENDENCY' => '13.7.0',
-            ),
-            'install' => array(),
-        ));
+            ],
+            'install' => [],
+        ]);
 
         $task = new CheckModuleCmsDependency(vfsStream::url('root/working'), vfsStream::url('root/install'));
         $this->assertTrue($this->handler->handle($task));
@@ -80,14 +80,14 @@ class CheckModuleCmsDependencyHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionWhenVersionConstraintIsInvalid()
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(
+        vfsStream::setup('root', null, [
+            'working' => [
                 'MODULE_CMS_DEPENDENCY' => '!! this is not a valid constraint',
-            ),
-            'install' => array(
+            ],
+            'install' => [
                 'VERSION' => '1.2.3',
-            ),
-        ));
+            ],
+        ]);
 
         $task = new CheckModuleCmsDependency(vfsStream::url('root/working'), vfsStream::url('root/install'));
         $this->handler->handle($task);
@@ -98,14 +98,14 @@ class CheckModuleCmsDependencyHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testChecksModuleCmsDependency($moduleCmsDependency, $version, $expectedResult)
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(
+        vfsStream::setup('root', null, [
+            'working' => [
                 'MODULE_CMS_DEPENDENCY' => $moduleCmsDependency,
-            ),
-            'install' => array(
+            ],
+            'install' => [
                 'VERSION' => $version,
-            ),
-        ));
+            ],
+        ]);
 
         $task = new CheckModuleCmsDependency(vfsStream::url('root/working'), vfsStream::url('root/install'));
         $this->assertSame($expectedResult, $this->handler->handle($task));
@@ -113,29 +113,29 @@ class CheckModuleCmsDependencyHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function versionProvider()
     {
-        return array(
+        return [
             // Same version
-            array('13.7.0', '13.7.0', true),
+            ['13.7.0', '13.7.0', true],
 
             // Installed version is newer
-            array('13.7.0', '13.8.0', true),
-            array('13.7.0', '13.7.3', true),
-            array('13.7.0', '14.0.0', true),
+            ['13.7.0', '13.8.0', true],
+            ['13.7.0', '13.7.3', true],
+            ['13.7.0', '14.0.0', true],
 
             // Installed version is older
-            array('13.7.0', '13.6.0', false),
-            array('13.7.3', '13.7.0', false),
-            array('14.0.0', '13.6.0', false),
+            ['13.7.0', '13.6.0', false],
+            ['13.7.3', '13.7.0', false],
+            ['14.0.0', '13.6.0', false],
 
             // Version constraint check
-            array('^13', '13.6.0', true),
-            array('^13', '12.2.0', false),
-            array('~13.6.0', '13.6.0', true),
-            array('~13.6.0', '13.7.0', false),
-            array('=13.6.0', '13.6.0', true),
-            array('=13.6.0', '13.7.0', false),
-            array('13.6.0 - 13.6.4', '13.6.3', true),
-            array('13.6.0 - 13.6.4', '13.6.5', false),
-        );
+            ['^13', '13.6.0', true],
+            ['^13', '12.2.0', false],
+            ['~13.6.0', '13.6.0', true],
+            ['~13.6.0', '13.7.0', false],
+            ['=13.6.0', '13.6.0', true],
+            ['=13.6.0', '13.7.0', false],
+            ['13.6.0 - 13.6.4', '13.6.3', true],
+            ['13.6.0 - 13.6.4', '13.6.5', false],
+        ];
     }
 }

--- a/tests/Patch/Task/CheckVersionHandlerTest.php
+++ b/tests/Patch/Task/CheckVersionHandlerTest.php
@@ -20,15 +20,15 @@ class CheckVersionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowsNewerVersions()
     {
-        $config = array(
-            'package' => array(
+        $config = [
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        $versions = array(
+        $versions = [
             new VersionDiff('test', 'VERSION', '1.1.0', '1.0.0'),
-        );
+        ];
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with('working', 'install', $config)
@@ -40,15 +40,15 @@ class CheckVersionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testPreventsOlderVersionFromBeingPatched()
     {
-        $config = array(
-            'package' => array(
+        $config = [
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        $versions = array(
+        $versions = [
             new VersionDiff('test', 'VERSION', '1.0.0', '1.1.0'),
-        );
+        ];
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with('working', 'install', $config)
@@ -60,15 +60,15 @@ class CheckVersionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowsOlderVersionsForRollback()
     {
-        $config = array(
-            'package' => array(
+        $config = [
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        $versions = array(
+        $versions = [
             new VersionDiff('test', 'VERSION', '1.0.0', '1.1.0'),
-        );
+        ];
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with('working', 'install', $config)
@@ -80,15 +80,15 @@ class CheckVersionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testPreventsNewerVersionFromBeingPatchedForRollback()
     {
-        $config = array(
-            'package' => array(
+        $config = [
+            'package' => [
                 'version' => 'VERSION',
-            ),
-        );
+            ],
+        ];
 
-        $versions = array(
+        $versions = [
             new VersionDiff('test', 'VERSION', '1.1.0', '1.0.0'),
-        );
+        ];
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with('working', 'install', $config)

--- a/tests/Patch/Task/CopyFilesHandlerTest.php
+++ b/tests/Patch/Task/CopyFilesHandlerTest.php
@@ -16,14 +16,14 @@ class CopyFilesHandlerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->io = new NullIO();
-        $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem', array(
-            'findNewFiles' => array(),
+        $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem', [
+            'findNewFiles' => [],
             'copyDirectory' => null,
-        ));
-        $this->permissionSetter = Mockery::mock('Meteor\Permissions\PermissionSetter', array(
+        ]);
+        $this->permissionSetter = Mockery::mock('Meteor\Permissions\PermissionSetter', [
             'setDefaultPermissions' => null,
             'setPermissions' => null,
-        ));
+        ]);
         $this->handler = new CopyFilesHandler($this->io, $this->filesystem, $this->permissionSetter);
     }
 
@@ -33,14 +33,14 @@ class CopyFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->with('source', 'target')
             ->once();
 
-        $this->handler->handle(new CopyFiles('source', 'target'), array());
+        $this->handler->handle(new CopyFiles('source', 'target'), []);
     }
 
     public function testSetsPermissions()
     {
-        $newFiles = array(
+        $newFiles = [
             'test',
-        );
+        ];
 
         $this->filesystem->shouldReceive('findNewFiles')
             ->with('source', 'target')
@@ -57,6 +57,6 @@ class CopyFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->ordered()
             ->once();
 
-        $this->handler->handle(new CopyFiles('source', 'target'), array());
+        $this->handler->handle(new CopyFiles('source', 'target'), []);
     }
 }

--- a/tests/Patch/Task/DeleteBackupHandlerTest.php
+++ b/tests/Patch/Task/DeleteBackupHandlerTest.php
@@ -14,10 +14,10 @@ class DeleteBackupHandlerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->io = new NullIO();
-        $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem', array(
-            'findNewFiles' => array(),
+        $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem', [
+            'findNewFiles' => [],
             'copyDirectory' => null,
-        ));
+        ]);
 
         $this->handler = new DeleteBackupHandler($this->io, $this->filesystem);
     }

--- a/tests/Patch/Task/DisplayVersionInfoHandlerTest.php
+++ b/tests/Patch/Task/DisplayVersionInfoHandlerTest.php
@@ -14,24 +14,24 @@ class DisplayVersionInfoHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->io = Mockery::mock('Meteor\IO\IOInterface', array(
+        $this->io = Mockery::mock('Meteor\IO\IOInterface', [
             'text' => null,
             'newLine' => null,
-        ));
+        ]);
         $this->versionComparer = Mockery::mock('Meteor\Patch\Version\VersionComparer');
         $this->handler = new DisplayVersionInfoHandler($this->io, $this->versionComparer);
     }
 
     public function testHandleDoesntOutputWhenThereAreNoVersions()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'combined' => array(
-            ),
-        );
+            'combined' => [
+            ],
+        ];
 
-        $versions = array(
-        );
+        $versions = [
+        ];
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with('working', 'install', $config)
@@ -41,8 +41,8 @@ class DisplayVersionInfoHandlerTest extends \PHPUnit_Framework_TestCase
         $this->io->shouldNotReceive('table')
             ->with(
                 Mockery::any(),
-                array(
-                )
+                [
+                ]
             );
 
         $this->handler->handle(new DisplayVersionInfo('working', 'install'), $config);
@@ -50,32 +50,32 @@ class DisplayVersionInfoHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleOutputsPackageVersionInfo()
     {
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'XFP_VERSION',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'jadu/cp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'CP_VERSION',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
-        $versions = array(
+        $versions = [
             new VersionDiff('jadu/cms', 'VERSION', '1.1.0', '1.0.0'),
             new VersionDiff('jadu/xfp', 'XFP_VERSION', '1.1.0', '1.2.0'),
             new VersionDiff('jadu/cp', 'CP_VERSION', '1.0.0', '1.0.0'),
-        );
+        ];
 
         $this->versionComparer->shouldReceive('comparePackage')
             ->with('working', 'install', $config)
@@ -85,11 +85,11 @@ class DisplayVersionInfoHandlerTest extends \PHPUnit_Framework_TestCase
         $this->io->shouldReceive('table')
             ->with(
                 Mockery::any(),
-                array(
-                    array('jadu/cms', 'VERSION', '1.0.0', '1.1.0', '<fg=green>Newer</>'),
-                    array('jadu/xfp', 'XFP_VERSION', '1.2.0', '1.1.0', '<fg=red>Older</>'),
-                    array('jadu/cp', 'CP_VERSION', '1.0.0', '1.0.0', '<fg=yellow>No change</>'),
-                )
+                [
+                    ['jadu/cms', 'VERSION', '1.0.0', '1.1.0', '<fg=green>Newer</>'],
+                    ['jadu/xfp', 'XFP_VERSION', '1.2.0', '1.1.0', '<fg=red>Older</>'],
+                    ['jadu/cp', 'CP_VERSION', '1.0.0', '1.0.0', '<fg=yellow>No change</>'],
+                ]
             )
             ->once();
 

--- a/tests/Patch/Task/MigrateDownHandlerTest.php
+++ b/tests/Patch/Task/MigrateDownHandlerTest.php
@@ -24,12 +24,12 @@ class MigrateDownHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsFileMigrationsIfConfigured()
     {
-        $config = array(
+        $config = [
             'name' => 'root',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'Migrations',
-            ),
-        );
+            ],
+        ];
 
         $this->versionFileManager->shouldReceive('getCurrentVersion')
             ->with('backups/1', 'Migrations', 'FILE_SYSTEM_MIGRATION_NUMBER')
@@ -47,12 +47,12 @@ class MigrateDownHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsDatabaseMigrationsIfConfigured()
     {
-        $config = array(
+        $config = [
             'name' => 'root',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'Migrations',
-            ),
-        );
+            ],
+        ];
 
         $this->versionFileManager->shouldReceive('getCurrentVersion')
             ->with('backups/1', 'Migrations', 'MIGRATION_NUMBER')
@@ -70,16 +70,16 @@ class MigrateDownHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsCombinedPackageMigrationsIfConfigured()
     {
-        $config = array(
-            'combined' => array(
-                array(
+        $config = [
+            'combined' => [
+                [
                     'name' => 'test',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->versionFileManager->shouldReceive('getCurrentVersion')
             ->with('backups/1', 'Migrations', 'FILE_SYSTEM_MIGRATION_NUMBER')
@@ -97,26 +97,26 @@ class MigrateDownHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsMigrationsInReverseOrder()
     {
-        $config = array(
+        $config = [
             'name' => 'root',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'Migrations',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'test1',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations1',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'test2',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations2',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->versionFileManager->shouldReceive('getCurrentVersion')
             ->with('backups/1', $config['migrations']['table'], 'FILE_SYSTEM_MIGRATION_NUMBER')
@@ -160,20 +160,20 @@ class MigrateDownHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHaltsHandlerIfMigrationsFail()
     {
-        $config = array(
+        $config = [
             'name' => 'root',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'Migrations',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'test',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->versionFileManager->shouldReceive('getCurrentVersion')
             ->andReturn('0');
@@ -193,22 +193,22 @@ class MigrateDownHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHaltsHandlerIfCombinedPackageMigrationsFail()
     {
-        $config = array(
-            'combined' => array(
-                array(
+        $config = [
+            'combined' => [
+                [
                     'name' => 'test',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations1',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'test2',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations2',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->versionFileManager->shouldReceive('getCurrentVersion')
             ->andReturn('0');

--- a/tests/Patch/Task/MigrateUpHandlerTest.php
+++ b/tests/Patch/Task/MigrateUpHandlerTest.php
@@ -22,12 +22,12 @@ class MigrateUpHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsFileMigrationsIfConfigured()
     {
-        $config = array(
+        $config = [
             'name' => 'root',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'Migrations',
-            ),
-        );
+            ],
+        ];
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_FILE, 'latest')
@@ -40,12 +40,12 @@ class MigrateUpHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsDatabaseMigrationsIfConfigured()
     {
-        $config = array(
+        $config = [
             'name' => 'root',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'Migrations',
-            ),
-        );
+            ],
+        ];
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_DATABASE, 'latest')
@@ -58,16 +58,16 @@ class MigrateUpHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsCombinedPackageMigrationsIfConfigured()
     {
-        $config = array(
-            'combined' => array(
-                array(
+        $config = [
+            'combined' => [
+                [
                     'name' => 'test',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][0]['migrations'], MigrationsConstants::TYPE_FILE, 'latest')
@@ -80,26 +80,26 @@ class MigrateUpHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunMigrationsInOrder()
     {
-        $config = array(
+        $config = [
             'name' => 'root',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'Migrations',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'test1',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations1',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'test2',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations2',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][0]['migrations'], MigrationsConstants::TYPE_FILE, 'latest')
@@ -125,20 +125,20 @@ class MigrateUpHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHaltsHandlerIfMigrationsFail()
     {
-        $config = array(
+        $config = [
             'name' => 'root',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'Migrations',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'test',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_FILE, 'latest')
@@ -155,22 +155,22 @@ class MigrateUpHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHaltsHandlerIfCombinedPackageMigrationsFail()
     {
-        $config = array(
-            'combined' => array(
-                array(
+        $config = [
+            'combined' => [
+                [
                     'name' => 'test',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'test2',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations2',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][0]['migrations'], MigrationsConstants::TYPE_FILE, 'latest')

--- a/tests/Patch/Task/MockTaskBus.php
+++ b/tests/Patch/Task/MockTaskBus.php
@@ -4,7 +4,7 @@ namespace Meteor\Patch\Task;
 
 class MockTaskBus implements TaskBusInterface
 {
-    public $handled = array();
+    public $handled = [];
 
     public function run($task, array $config)
     {

--- a/tests/Patch/Task/TaskBusTest.php
+++ b/tests/Patch/Task/TaskBusTest.php
@@ -20,7 +20,7 @@ class TaskBusTest extends \PHPUnit_Framework_TestCase
         $this->taskBus->registerHandler('stdClass', $handler);
 
         $task = new \stdClass();
-        $config = array('name' => 'value');
+        $config = ['name' => 'value'];
 
         $handler->shouldReceive('handle')
             ->with($task, $config)
@@ -35,6 +35,6 @@ class TaskBusTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionWhenMissingHandler()
     {
-        $this->taskBus->run(new \stdClass(), array('name' => 'value'));
+        $this->taskBus->run(new \stdClass(), ['name' => 'value']);
     }
 }

--- a/tests/Patch/Task/UpdateMigrationVersionFilesHandlerTest.php
+++ b/tests/Patch/Task/UpdateMigrationVersionFilesHandlerTest.php
@@ -27,16 +27,16 @@ class UpdateMigrationVersionFilesHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetsCurrentVersion()
     {
-        $config = array(
+        $config = [
             'name' => 'root',
-            'migrations' => array(
+            'migrations' => [
                 'table' => 'Migrations',
-            ),
-        );
+            ],
+        ];
 
-        $databaseConfiguration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', array(
+        $databaseConfiguration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', [
             'getCurrentVersion' => '20160701000000',
-        ));
+        ]);
 
         $this->configurationFactory->shouldReceive('createConfiguration')
             ->with(MigrationsConstants::TYPE_DATABASE, $config['migrations'], 'patch', 'install')
@@ -47,9 +47,9 @@ class UpdateMigrationVersionFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->with('20160701000000', 'backup', 'Migrations', VersionFileManager::DATABASE_MIGRATION)
             ->once();
 
-        $fileConfiguration = Mockery::mock('Meteor\Migrations\Configuration\FileConfiguration', array(
+        $fileConfiguration = Mockery::mock('Meteor\Migrations\Configuration\FileConfiguration', [
             'getCurrentVersion' => '20160701000000',
-        ));
+        ]);
 
         $this->configurationFactory->shouldReceive('createConfiguration')
             ->with(MigrationsConstants::TYPE_FILE, $config['migrations'], 'patch', 'install')
@@ -65,20 +65,20 @@ class UpdateMigrationVersionFilesHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetsCurrentVersionForCombinedPackageMigrations()
     {
-        $config = array(
-            'combined' => array(
-                array(
+        $config = [
+            'combined' => [
+                [
                     'name' => 'test',
-                    'migrations' => array(
+                    'migrations' => [
                         'table' => 'Migrations',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
-        $databaseConfiguration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', array(
+        $databaseConfiguration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', [
             'getCurrentVersion' => '20160701000000',
-        ));
+        ]);
 
         $this->configurationFactory->shouldReceive('createConfiguration')
             ->with(MigrationsConstants::TYPE_DATABASE, $config['combined'][0]['migrations'], 'patch', 'install')
@@ -89,9 +89,9 @@ class UpdateMigrationVersionFilesHandlerTest extends \PHPUnit_Framework_TestCase
             ->with('20160701000000', 'backup', 'Migrations', VersionFileManager::DATABASE_MIGRATION)
             ->once();
 
-        $fileConfiguration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', array(
+        $fileConfiguration = Mockery::mock('Meteor\Migrations\Configuration\DatabaseConfiguration', [
             'getCurrentVersion' => '20160701000000',
-        ));
+        ]);
 
         $this->configurationFactory->shouldReceive('createConfiguration')
             ->with(MigrationsConstants::TYPE_FILE, $config['combined'][0]['migrations'], 'patch', 'install')

--- a/tests/Patch/Version/VersionComparerTest.php
+++ b/tests/Patch/Version/VersionComparerTest.php
@@ -15,14 +15,14 @@ class VersionComparerTest extends \PHPUnit_Framework_TestCase
 
     public function testCompare()
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(
+        vfsStream::setup('root', null, [
+            'working' => [
                 'VERSION' => '1.1.0',
-            ),
-            'install' => array(
+            ],
+            'install' => [
                 'VERSION' => '0.1.2',
-            ),
-        ));
+            ],
+        ]);
 
         $version = $this->versionComparer->compare(vfsStream::url('root/working'), vfsStream::url('root/install'), 'jadu/cms', 'VERSION');
 
@@ -35,39 +35,39 @@ class VersionComparerTest extends \PHPUnit_Framework_TestCase
 
     public function testComparePackage()
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(
+        vfsStream::setup('root', null, [
+            'working' => [
                 'VERSION' => '1.1.0',
                 'XFP_VERSION' => '2.0.0',
                 'CP_VERSION' => '0.0.1',
-            ),
-            'install' => array(
+            ],
+            'install' => [
                 'VERSION' => '1.1.2',
                 'XFP_VERSION' => '3.0.0',
                 'CP_VERSION' => '0.1.0',
-            ),
-        ));
+            ],
+        ]);
 
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'XFP_VERSION',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'jadu/cp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'CP_VERSION',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $versions = $this->versionComparer->comparePackage(vfsStream::url('root/working'), vfsStream::url('root/install'), $config);
 
@@ -94,37 +94,37 @@ class VersionComparerTest extends \PHPUnit_Framework_TestCase
 
     public function testComparePackageIgnoresVersionFilesThatDoNotExistInThePatchDir()
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(
+        vfsStream::setup('root', null, [
+            'working' => [
                 'VERSION' => '1.1.0',
-            ),
-            'install' => array(
+            ],
+            'install' => [
                 'VERSION' => '1.1.2',
                 'XFP_VERSION' => '3.0.0',
                 'CP_VERSION' => '0.1.0',
-            ),
-        ));
+            ],
+        ]);
 
-        $config = array(
+        $config = [
             'name' => 'jadu/cms',
-            'package' => array(
+            'package' => [
                 'version' => 'VERSION',
-            ),
-            'combined' => array(
-                array(
+            ],
+            'combined' => [
+                [
                     'name' => 'jadu/xfp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'XFP_VERSION',
-                    ),
-                ),
-                array(
+                    ],
+                ],
+                [
                     'name' => 'jadu/cp',
-                    'package' => array(
+                    'package' => [
                         'version' => 'CP_VERSION',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $versions = $this->versionComparer->comparePackage(vfsStream::url('root/working'), vfsStream::url('root/install'), $config);
 
@@ -142,10 +142,10 @@ class VersionComparerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCompareThrowsExceptionWhenUnableToFindVersionFileInWorkingDir()
     {
-        vfsStream::setup('root', null, array(
-            'working' => array(),
-            'install' => array(),
-        ));
+        vfsStream::setup('root', null, [
+            'working' => [],
+            'install' => [],
+        ]);
 
         $this->versionComparer->compare(vfsStream::url('root/working'), vfsStream::url('root/install'), 'test', 'VERSION');
     }

--- a/tests/Patch/Version/VersionDiffTest.php
+++ b/tests/Patch/Version/VersionDiffTest.php
@@ -16,15 +16,15 @@ class VersionDiffTest extends \PHPUnit_Framework_TestCase
 
     public function lessThanProvider()
     {
-        return array(
-            array('1.0.0', '1.0.0', false),
-            array('3.0.0', '4.0.0', true),
-            array('3.0.0', '4.0.0-CMS-branch-123', true),
-            array('1.0.0', '0.1.0', false),
-            array('1.0.0', '0.0.1', false),
-            array('2.1.0', '2.0.0', false),
-            array('2.1.0-CMS-branch-123', '2.0.0', false),
-        );
+        return [
+            ['1.0.0', '1.0.0', false],
+            ['3.0.0', '4.0.0', true],
+            ['3.0.0', '4.0.0-CMS-branch-123', true],
+            ['1.0.0', '0.1.0', false],
+            ['1.0.0', '0.0.1', false],
+            ['2.1.0', '2.0.0', false],
+            ['2.1.0-CMS-branch-123', '2.0.0', false],
+        ];
     }
 
     /**
@@ -39,14 +39,14 @@ class VersionDiffTest extends \PHPUnit_Framework_TestCase
 
     public function greaterThanProvider()
     {
-        return array(
-            array('1.0.0', '1.0.0', false),
-            array('3.0.0', '4.0.0-CMS-branch-123', false),
-            array('3.0.0', '4.0.0', false),
-            array('1.0.0', '0.1.0', true),
-            array('1.0.0', '0.0.1', true),
-            array('2.1.0', '2.0.0', true),
-            array('2.1.0-CMS-branch-123', '2.0.0', true),
-        );
+        return [
+            ['1.0.0', '1.0.0', false],
+            ['3.0.0', '4.0.0-CMS-branch-123', false],
+            ['3.0.0', '4.0.0', false],
+            ['1.0.0', '0.1.0', true],
+            ['1.0.0', '0.0.1', true],
+            ['2.1.0', '2.0.0', true],
+            ['2.1.0-CMS-branch-123', '2.0.0', true],
+        ];
     }
 }

--- a/tests/Permissions/PermissionLoaderTest.php
+++ b/tests/Permissions/PermissionLoaderTest.php
@@ -15,13 +15,13 @@ class PermissionLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $permissions = $this->loader->load(__DIR__.'/Fixtures');
 
-        $this->assertEquals(Permission::create('public_html/.htaccess*', array('r', 'w')), $permissions[0]);
+        $this->assertEquals(Permission::create('public_html/.htaccess*', ['r', 'w']), $permissions[0]);
     }
 
     public function testLoadIgnoresExtraWhitespace()
     {
         $permissions = $this->loader->load(__DIR__.'/Fixtures');
 
-        $this->assertEquals(Permission::create('var/tmp', array('r', 'w', 'x', 'R')), $permissions[38]);
+        $this->assertEquals(Permission::create('var/tmp', ['r', 'w', 'x', 'R']), $permissions[38]);
     }
 }

--- a/tests/Permissions/PermissionSetterTest.php
+++ b/tests/Permissions/PermissionSetterTest.php
@@ -24,9 +24,9 @@ class PermissionSetterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetDefaultPermissions()
     {
-        $files = array(
+        $files = [
             'test',
-        );
+        ];
 
         $this->platform->shouldReceive('setDefaultPermission')
             ->with('target', 'test')
@@ -37,9 +37,9 @@ class PermissionSetterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetDefaultPermissionsCatchesExceptions()
     {
-        $files = array(
+        $files = [
             'test',
-        );
+        ];
 
         $this->platform->shouldReceive('setDefaultPermission')
             ->andThrow(new Exception())
@@ -50,28 +50,28 @@ class PermissionSetterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissions()
     {
-        vfsStream::setup('root', null, array(
-            'base' => array(
-                'var' => array(
-                    'config' => array(
+        vfsStream::setup('root', null, [
+            'base' => [
+                'var' => [
+                    'config' => [
                         'system.xml' => '',
-                    ),
-                ),
-            ),
-            'target' => array(
-                'var' => array(
-                    'config' => array(
+                    ],
+                ],
+            ],
+            'target' => [
+                'var' => [
+                    'config' => [
                         'system.xml' => '',
-                    ),
-                ),
-            ),
-        ));
+                    ],
+                ],
+            ],
+        ]);
 
         $permission = new Permission('var/config');
 
         $this->permissionLoader->shouldReceive('load')
             ->with(vfsStream::url('root/target'))
-            ->andReturn(array($permission))
+            ->andReturn([$permission])
             ->once();
 
         $this->platform->shouldReceive('setPermission')
@@ -83,30 +83,30 @@ class PermissionSetterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionsWithWildcardPattern()
     {
-        vfsStream::setup('root', null, array(
-            'base' => array(
-                'var' => array(
-                    'config' => array(
+        vfsStream::setup('root', null, [
+            'base' => [
+                'var' => [
+                    'config' => [
                         'system.xml' => '',
                         'constants.xml' => '',
-                    ),
-                ),
-            ),
-            'target' => array(
-                'var' => array(
-                    'config' => array(
+                    ],
+                ],
+            ],
+            'target' => [
+                'var' => [
+                    'config' => [
                         'system.xml' => '',
                         'constants.xml' => '',
-                    ),
-                ),
-            ),
-        ));
+                    ],
+                ],
+            ],
+        ]);
 
         $permission = new Permission('var/config/*.xml');
 
         $this->permissionLoader->shouldReceive('load')
             ->with(vfsStream::url('root/target'))
-            ->andReturn(array($permission))
+            ->andReturn([$permission])
             ->once();
 
         $this->platform->shouldReceive('setPermission')
@@ -122,28 +122,28 @@ class PermissionSetterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionsCatchesExceptions()
     {
-        vfsStream::setup('root', null, array(
-            'base' => array(
-                'var' => array(
-                    'config' => array(
+        vfsStream::setup('root', null, [
+            'base' => [
+                'var' => [
+                    'config' => [
                         'system.xml' => '',
-                    ),
-                ),
-            ),
-            'target' => array(
-                'var' => array(
-                    'config' => array(
+                    ],
+                ],
+            ],
+            'target' => [
+                'var' => [
+                    'config' => [
                         'system.xml' => '',
-                    ),
-                ),
-            ),
-        ));
+                    ],
+                ],
+            ],
+        ]);
 
         $permission = new Permission('var/config');
 
         $this->permissionLoader->shouldReceive('load')
             ->with(vfsStream::url('root/target'))
-            ->andReturn(array($permission))
+            ->andReturn([$permission])
             ->once();
 
         $this->platform->shouldReceive('setPermission')

--- a/tests/Permissions/PermissionTest.php
+++ b/tests/Permissions/PermissionTest.php
@@ -12,7 +12,7 @@ class PermissionTest extends \PHPUnit_Framework_TestCase
         $expectedPermission->setExecute(true);
         $expectedPermission->setRecursive(true);
 
-        $this->assertEquals($expectedPermission, Permission::create('test/*', array('r', 'w', 'x', 'R')));
+        $this->assertEquals($expectedPermission, Permission::create('test/*', ['r', 'w', 'x', 'R']));
     }
 
     public function testCreateWithNoPermissions()
@@ -23,7 +23,7 @@ class PermissionTest extends \PHPUnit_Framework_TestCase
         $expectedPermission->setExecute(false);
         $expectedPermission->setRecursive(false);
 
-        $this->assertEquals($expectedPermission, Permission::create('test/*', array()));
+        $this->assertEquals($expectedPermission, Permission::create('test/*', []));
     }
 
     public function testCreateWithSomePermissions()
@@ -34,14 +34,14 @@ class PermissionTest extends \PHPUnit_Framework_TestCase
         $expectedPermission->setExecute(true);
         $expectedPermission->setRecursive(false);
 
-        $this->assertEquals($expectedPermission, Permission::create('test/*', array('r', 'x')));
+        $this->assertEquals($expectedPermission, Permission::create('test/*', ['r', 'x']));
     }
 
     public function testCreateWithExtraWhitespaceInPath()
     {
         $expectedPermission = new Permission('    test/*    ');
 
-        $this->assertEquals($expectedPermission, Permission::create('test/*', array()));
+        $this->assertEquals($expectedPermission, Permission::create('test/*', []));
     }
 
     /**
@@ -55,11 +55,11 @@ class PermissionTest extends \PHPUnit_Framework_TestCase
 
     public function matchesProvider()
     {
-        return array(
-            array('test', 'test', true),
-            array('test', 'other/test', false),
-            array('config/*.xml', 'config/system.xml', true),
-            array('config/*.xml', 'config/system.xml.dist', false),
-        );
+        return [
+            ['test', 'test', true],
+            ['test', 'other/test', false],
+            ['config/*.xml', 'config/system.xml', true],
+            ['config/*.xml', 'config/system.xml.dist', false],
+        ];
     }
 }

--- a/tests/Permissions/ServiceContainer/PermissionsExtensionTest.php
+++ b/tests/Permissions/ServiceContainer/PermissionsExtensionTest.php
@@ -8,7 +8,7 @@ class PermissionsExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,10 +17,10 @@ class PermissionsExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             PermissionsExtension::SERVICE_COMMAND_RESET_PERMISSIONS,
             PermissionsExtension::SERVICE_PERMISSION_LOADER,
             PermissionsExtension::SERVICE_PERMISSION_SETTER,
-        );
+        ];
     }
 }

--- a/tests/Platform/ServiceContainer/PlatformExtensionTest.php
+++ b/tests/Platform/ServiceContainer/PlatformExtensionTest.php
@@ -8,7 +8,7 @@ class PlatformExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,11 +17,11 @@ class PlatformExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             PlatformExtension::SERVICE_PLATFORM_UNIX,
             PlatformExtension::SERVICE_PLATFORM_WINDOWS,
             PlatformExtension::SERVICE_UNIX_INSTALL_CONFIG_LOADER,
-        );
+        ];
     }
 
     /**
@@ -33,7 +33,7 @@ class PlatformExtensionTest extends ExtensionTestCase
             define('PHP_WINDOWS_VERSION_BUILD', 1);
         }
 
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         $this->assertInstanceOf(
             'Meteor\Platform\Windows\WindowsPlatform',

--- a/tests/Platform/Unix/InstallConfigLoaderTest.php
+++ b/tests/Platform/Unix/InstallConfigLoaderTest.php
@@ -70,9 +70,9 @@ FINISHED_INSTALL_PHASES="check_config_templates"
 PHPWRAPPER_FILE="php-wrapper"
 CONF;
 
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'install.conf' => $installConf,
-        ));
+        ]);
 
         $config = $this->loader->load(vfsStream::url('root'));
 
@@ -100,9 +100,9 @@ CONF;
      */
     public function testLoadThrowsExceptionWhenFileCannotBeParsed()
     {
-        vfsStream::setup('root', null, array(
+        vfsStream::setup('root', null, [
             'install.conf' => '!',
-        ));
+        ]);
 
         $this->loader->load(vfsStream::url('root'));
     }

--- a/tests/Platform/Unix/InstallConfigTest.php
+++ b/tests/Platform/Unix/InstallConfigTest.php
@@ -6,20 +6,20 @@ class InstallConfigTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetWebUserFallsBackToApacheUserWhenNotSuexec()
     {
-        $config = new InstallConfig(array(
+        $config = new InstallConfig([
             'SUEXEC' => 'no',
             'APACHE_USER' => 'apache',
-        ));
+        ]);
 
         $this->assertSame('apache', $config->getWebUser());
     }
 
     public function testGetWebGroupFallsBackToApacheGroupWhenNotSuexec()
     {
-        $config = new InstallConfig(array(
+        $config = new InstallConfig([
             'SUEXEC' => 'no',
             'APACHE_GROUP' => 'apache',
-        ));
+        ]);
 
         $this->assertSame('apache', $config->getWebGroup());
     }
@@ -29,20 +29,20 @@ class InstallConfigTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsSuexec($value, $expectedResult)
     {
-        $config = new InstallConfig(array(
+        $config = new InstallConfig([
             'SUEXEC' => $value,
-        ));
+        ]);
 
         $this->assertSame($expectedResult, $config->isSuexec());
     }
 
     public function suexecValueProvider()
     {
-        return array(
-            array('', false),
-            array('n', false),
-            array('y', false),
-            array('yes', true),
-        );
+        return [
+            ['', false],
+            ['n', false],
+            ['y', false],
+            ['yes', true],
+        ];
     }
 }

--- a/tests/Platform/Unix/UnixPlatformTest.php
+++ b/tests/Platform/Unix/UnixPlatformTest.php
@@ -16,35 +16,35 @@ class UnixPlatformTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem');
-        $this->installConfig = Mockery::mock('Meteor\Platform\Unix\InstallConfig', array(
+        $this->installConfig = Mockery::mock('Meteor\Platform\Unix\InstallConfig', [
             'getUser' => 'jadu',
             'getGroup' => 'jadu',
             'getWebUser' => 'jadu-www',
             'getWebGroup' => 'jadu-www',
-        ));
-        $this->installConfigLoader = Mockery::mock('Meteor\Platform\Unix\InstallConfigLoader', array(
+        ]);
+        $this->installConfigLoader = Mockery::mock('Meteor\Platform\Unix\InstallConfigLoader', [
             'load' => $this->installConfig,
-        ));
+        ]);
 
         $this->platform = new UnixPlatform($this->installConfigLoader, $this->filesystem);
         $this->platform->setInstallDir('install');
 
-        vfsStream::setup('root', null, array(
-            'jadu' => array(
-                'custom' => array(
+        vfsStream::setup('root', null, [
+            'jadu' => [
+                'custom' => [
                     'JaduCustom.php' => '<?php ?>',
-                ),
+                ],
                 'JaduConstants.php' => '<?php ?>',
-            ),
-            'public_html' => array(
+            ],
+            'public_html' => [
                 'file.txt' => 'Hello',
-            ),
-        ));
+            ],
+        ]);
     }
 
     public function testSetPermissionWithFile()
     {
-        $permission = Permission::create('', array('r', 'w'));
+        $permission = Permission::create('', ['r', 'w']);
 
         $this->filesystem->shouldReceive('chgrp')
             ->with('vfs://root/jadu/JaduConstants.php', 'jadu-www', false)
@@ -59,7 +59,7 @@ class UnixPlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionWithFileAndNoPermissions()
     {
-        $permission = Permission::create('', array());
+        $permission = Permission::create('', []);
 
         $this->filesystem->shouldReceive('chgrp')
             ->with('vfs://root/jadu/JaduConstants.php', 'jadu-www', false)
@@ -74,7 +74,7 @@ class UnixPlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionWithDirectory()
     {
-        $permission = Permission::create('', array('r', 'w', 'x', 'R'));
+        $permission = Permission::create('', ['r', 'w', 'x', 'R']);
 
         $this->filesystem->shouldReceive('chgrp')
             ->with('vfs://root/jadu/custom', 'jadu-www', true)
@@ -89,7 +89,7 @@ class UnixPlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionWithDirectoryAndNoPermissions()
     {
-        $permission = Permission::create('', array());
+        $permission = Permission::create('', []);
 
         $this->filesystem->shouldReceive('chgrp')
             ->with('vfs://root/jadu/custom', 'jadu-www', false)
@@ -104,7 +104,7 @@ class UnixPlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionWithFileIgnoresRecursiveFlag()
     {
-        $permission = Permission::create('', array('r', 'w', 'x', 'R'));
+        $permission = Permission::create('', ['r', 'w', 'x', 'R']);
 
         $this->filesystem->shouldReceive('chgrp')
             ->with('vfs://root/jadu/JaduConstants.php', 'jadu-www', false)

--- a/tests/Platform/Windows/WindowsPlatformTest.php
+++ b/tests/Platform/Windows/WindowsPlatformTest.php
@@ -16,22 +16,22 @@ class WindowsPlatformTest extends \PHPUnit_Framework_TestCase
         $this->processRunner = Mockery::mock('Meteor\Process\ProcessRunner');
         $this->platform = new WindowsPlatform($this->processRunner);
 
-        vfsStream::setup('root', null, array(
-            'jadu' => array(
-                'custom' => array(
+        vfsStream::setup('root', null, [
+            'jadu' => [
+                'custom' => [
                     'JaduCustom.php' => '<?php ?>',
-                ),
+                ],
                 'JaduConstants.php' => '<?php ?>',
-            ),
-            'public_html' => array(
+            ],
+            'public_html' => [
                 'file.txt' => 'Hello',
-            ),
-        ));
+            ],
+        ]);
     }
 
     public function testSetPermissionWithFile()
     {
-        $permission = Permission::create('', array('r', 'w', 'x'));
+        $permission = Permission::create('', ['r', 'w', 'x']);
 
         $this->processRunner->shouldReceive('run')
             ->with("icacls 'vfs://root/jadu/JaduConstants.php' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:RXWM' /Q")
@@ -42,7 +42,7 @@ class WindowsPlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionWithDirectory()
     {
-        $permission = Permission::create('', array('r', 'w', 'x'));
+        $permission = Permission::create('', ['r', 'w', 'x']);
 
         $this->processRunner->shouldReceive('run')
             ->with("icacls 'vfs://root/jadu/custom' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:(OI)(CI)RXWM' /Q")
@@ -53,7 +53,7 @@ class WindowsPlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionWithDirectoryAndRecursive()
     {
-        $permission = Permission::create('', array('r', 'w', 'x', 'R'));
+        $permission = Permission::create('', ['r', 'w', 'x', 'R']);
 
         $this->processRunner->shouldReceive('run')
             ->with("icacls 'vfs://root/jadu/custom' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:(OI)(CI)RXWM' /t /Q")
@@ -64,7 +64,7 @@ class WindowsPlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionWithFileIgnoresRecursiveFlag()
     {
-        $permission = Permission::create('', array('r', 'w', 'x', 'R'));
+        $permission = Permission::create('', ['r', 'w', 'x', 'R']);
 
         $this->processRunner->shouldReceive('run')
             ->with("icacls 'vfs://root/jadu/JaduConstants.php' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:RXWM' /Q")
@@ -75,7 +75,7 @@ class WindowsPlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPermissionWithExecuteButNotWritePermission()
     {
-        $permission = Permission::create('', array('x'));
+        $permission = Permission::create('', ['x']);
 
         $this->processRunner->shouldReceive('run')
             ->with("icacls 'vfs://root/jadu/JaduConstants.php' /remove:g 'IIS_IUSRS' /grant 'IIS_IUSRS:RX' /Q")

--- a/tests/Process/ServiceContainer/ProcessExtensionTest.php
+++ b/tests/Process/ServiceContainer/ProcessExtensionTest.php
@@ -8,7 +8,7 @@ class ProcessExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,8 +17,8 @@ class ProcessExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             ProcessExtension::SERVICE_PROCESS_RUNNER,
-        );
+        ];
     }
 }

--- a/tests/Scripts/Cli/Command/RunCommandTest.php
+++ b/tests/Scripts/Cli/Command/RunCommandTest.php
@@ -14,7 +14,7 @@ class RunCommandTest extends CommandTestCase
     {
         $this->scriptRunner = Mockery::mock('Meteor\Scripts\ScriptRunner');
 
-        return new RunCommand(null, array('name' => 'test'), new NullIO(), $this->scriptRunner);
+        return new RunCommand(null, ['name' => 'test'], new NullIO(), $this->scriptRunner);
     }
 
     public function testRunsCommand()
@@ -30,9 +30,9 @@ class RunCommandTest extends CommandTestCase
             ->andReturn(true)
             ->once();
 
-        $this->tester->execute(array(
+        $this->tester->execute([
             'script' => 'test',
             '--working-dir' => $workingDir,
-        ));
+        ]);
     }
 }

--- a/tests/Scripts/EventListener/ScriptEventListenerTest.php
+++ b/tests/Scripts/EventListener/ScriptEventListenerTest.php
@@ -20,12 +20,11 @@ class ScriptEventListenerTest extends \PHPUnit_Framework_TestCase
     public function testHandleEvent()
     {
         $event = new Event();
-        $event->setName('test');
 
         $this->scriptRunner->shouldReceive('run')
             ->with('test')
             ->once();
 
-        $this->listener->handleEvent($event);
+        $this->listener->handleEvent($event, 'test');
     }
 }

--- a/tests/Scripts/ScriptRunnerTest.php
+++ b/tests/Scripts/ScriptRunnerTest.php
@@ -17,17 +17,17 @@ class ScriptRunnerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunHandlesUnknownScriptsGracefully()
     {
-        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), array());
+        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), []);
         $scriptRunner->run('test');
     }
 
     public function testRunsCustomerScriptCommand()
     {
-        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), array(
-            'spacecraft/customer' => array(
-                'test' => array('ls'),
-            ),
-        ));
+        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), [
+            'spacecraft/customer' => [
+                'test' => ['ls'],
+            ],
+        ]);
 
         $this->processRunner->shouldReceive('run')
             ->with('ls', null)
@@ -38,11 +38,11 @@ class ScriptRunnerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsCombinedScriptCommand()
     {
-        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), array(
-            'jadu/cms' => array(
-                'test' => array('ls'),
-            ),
-        ));
+        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), [
+            'jadu/cms' => [
+                'test' => ['ls'],
+            ],
+        ]);
 
         $this->processRunner->shouldReceive('run')
             ->with('ls', null)
@@ -53,11 +53,11 @@ class ScriptRunnerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsAllCustomerCommands()
     {
-        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), array(
-            'spacecraft/customer' => array(
-                'test' => array('test1', 'test2'),
-            ),
-        ));
+        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), [
+            'spacecraft/customer' => [
+                'test' => ['test1', 'test2'],
+            ],
+        ]);
 
         $this->processRunner->shouldReceive('run')
             ->with('test1', null)
@@ -72,17 +72,17 @@ class ScriptRunnerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsCustomerAndCombinedScriptCommands()
     {
-        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), array(
-            'spacecraft/customer' => array(
-                'test' => array('test1', 'test2'),
-            ),
-            'jadu/cms' => array(
-                'test' => array('test3'),
-            ),
-            'spacecraft/client' => array(
-                'test' => array('test4'),
-            ),
-        ));
+        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), [
+            'spacecraft/customer' => [
+                'test' => ['test1', 'test2'],
+            ],
+            'jadu/cms' => [
+                'test' => ['test3'],
+            ],
+            'spacecraft/client' => [
+                'test' => ['test4'],
+            ],
+        ]);
 
         $this->processRunner->shouldReceive('run')
             ->with('test1', null)
@@ -105,11 +105,11 @@ class ScriptRunnerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsCustomerScriptCommandWithWorkingDirectory()
     {
-        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), array(
-            'spacecraft/customer' => array(
-                'test' => array('ls'),
-            ),
-        ));
+        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), [
+            'spacecraft/customer' => [
+                'test' => ['ls'],
+            ],
+        ]);
 
         $this->processRunner->shouldReceive('run')
             ->with('ls', 'install')
@@ -121,12 +121,12 @@ class ScriptRunnerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsCustomerReferencedScriptCommand()
     {
-        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), array(
-            'spacecraft/customer' => array(
-                'test' => array('@clear-cache'),
-                'clear-cache' => array('clear-cache.sh'),
-            ),
-        ));
+        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), [
+            'spacecraft/customer' => [
+                'test' => ['@clear-cache'],
+                'clear-cache' => ['clear-cache.sh'],
+            ],
+        ]);
 
         $this->processRunner->shouldReceive('run')
             ->with('clear-cache.sh', null)
@@ -137,12 +137,12 @@ class ScriptRunnerTest extends \PHPUnit_Framework_TestCase
 
     public function testRunsCombinedReferencedScriptCommand()
     {
-        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), array(
-            'jadu/cms' => array(
-                'test' => array('@clear-cache'),
-                'clear-cache' => array('clear-cache.sh'),
-            ),
-        ));
+        $scriptRunner = new ScriptRunner($this->processRunner, new NullIO(), [
+            'jadu/cms' => [
+                'test' => ['@clear-cache'],
+                'clear-cache' => ['clear-cache.sh'],
+            ],
+        ]);
 
         $this->processRunner->shouldReceive('run')
             ->with('clear-cache.sh', null)

--- a/tests/Scripts/ServiceContainer/ScriptsExtensionTest.php
+++ b/tests/Scripts/ServiceContainer/ScriptsExtensionTest.php
@@ -8,7 +8,7 @@ class ScriptsExtensionTest extends ExtensionTestCase
 {
     public function testServicesCanBeInstantiated()
     {
-        $container = $this->loadContainer(array());
+        $container = $this->loadContainer([]);
 
         foreach ($this->getServiceIds() as $serviceId) {
             $container->get($serviceId);
@@ -17,55 +17,55 @@ class ScriptsExtensionTest extends ExtensionTestCase
 
     private function getServiceIds()
     {
-        return array(
+        return [
             ScriptsExtension::SERVICE_EVENT_LISTENER,
             ScriptsExtension::SERVICE_SCRIPT_RUNNER,
-        );
+        ];
     }
 
     public function testConfigAllowsSingleCommands()
     {
-        $config = $this->processConfiguration(array(
-            'scripts' => array(
+        $config = $this->processConfiguration([
+            'scripts' => [
                 'test' => 'script',
-            ),
-        ));
+            ],
+        ]);
 
-        $this->assertArraySubset(array(
-            'scripts' => array(
-                'test' => array('script'),
-            ),
-        ), $config);
+        $this->assertArraySubset([
+            'scripts' => [
+                'test' => ['script'],
+            ],
+        ], $config);
     }
 
     public function testConfigAllowsGroupedCommands()
     {
-        $config = $this->processConfiguration(array(
-            'scripts' => array(
-                'test' => array('script1', 'script2'),
-            ),
-        ));
+        $config = $this->processConfiguration([
+            'scripts' => [
+                'test' => ['script1', 'script2'],
+            ],
+        ]);
 
-        $this->assertArraySubset(array(
-            'scripts' => array(
-                'test' => array('script1', 'script2'),
-            ),
-        ), $config);
+        $this->assertArraySubset([
+            'scripts' => [
+                'test' => ['script1', 'script2'],
+            ],
+        ], $config);
     }
 
     public function testConfigDoesNotNormalizeKeys()
     {
-        $config = $this->processConfiguration(array(
-            'scripts' => array(
-                'pre.patch.apply' => array('script'),
-            ),
-        ));
+        $config = $this->processConfiguration([
+            'scripts' => [
+                'pre.patch.apply' => ['script'],
+            ],
+        ]);
 
-        $this->assertArraySubset(array(
-            'scripts' => array(
-                'pre.patch.apply' => array('script'),
-            ),
-        ), $config);
+        $this->assertArraySubset([
+            'scripts' => [
+                'pre.patch.apply' => ['script'],
+            ],
+        ], $config);
     }
 
     /**
@@ -74,11 +74,11 @@ class ScriptsExtensionTest extends ExtensionTestCase
      */
     public function testConfigPreventsInfiniteRecursion()
     {
-        $this->processConfiguration(array(
-            'scripts' => array(
-                'test' => array('@test'),
-            ),
-        ));
+        $this->processConfiguration([
+            'scripts' => [
+                'test' => ['@test'],
+            ],
+        ]);
     }
 
     /**
@@ -87,12 +87,12 @@ class ScriptsExtensionTest extends ExtensionTestCase
      */
     public function testConfigPreventsInfiniteRecursionWithScriptReferences()
     {
-        $this->processConfiguration(array(
-            'scripts' => array(
-                'test1' => array('@test2'),
-                'test2' => array('@test1'),
-            ),
-        ));
+        $this->processConfiguration([
+            'scripts' => [
+                'test1' => ['@test2'],
+                'test2' => ['@test1'],
+            ],
+        ]);
     }
 
     /**
@@ -101,15 +101,15 @@ class ScriptsExtensionTest extends ExtensionTestCase
      */
     public function testConfigPreventsInfiniteRecursionWithDeepScriptReferences()
     {
-        $this->processConfiguration(array(
-            'scripts' => array(
-                'test1' => array('@test2'),
-                'test2' => array('@test3'),
-                'test3' => array('@test4'),
-                'test4' => array('@test5'),
-                'test5' => array('@test1'),
-            ),
-        ));
+        $this->processConfiguration([
+            'scripts' => [
+                'test1' => ['@test2'],
+                'test2' => ['@test3'],
+                'test3' => ['@test4'],
+                'test4' => ['@test5'],
+                'test5' => ['@test1'],
+            ],
+        ]);
     }
 
     /**
@@ -117,29 +117,29 @@ class ScriptsExtensionTest extends ExtensionTestCase
      */
     public function testConfigCannotContainMultiDimentionalScripts()
     {
-        $config = $this->processConfiguration(array(
-            'scripts' => array(
-                'test' => array(
-                    array('test'),
-                ),
-            ),
-        ));
+        $config = $this->processConfiguration([
+            'scripts' => [
+                'test' => [
+                    ['test'],
+                ],
+            ],
+        ]);
     }
 
     public function testLoadingMultipleConfigsWithReferencedScriptsDoesNotCauseCircularReferenceExceptionToBeThrown()
     {
-        $this->processConfiguration(array(
-            'scripts' => array(
-                'patch' => array('@test'),
-                'test' => array('test'),
-            ),
-        ));
+        $this->processConfiguration([
+            'scripts' => [
+                'patch' => ['@test'],
+                'test' => ['test'],
+            ],
+        ]);
 
-        $this->processConfiguration(array(
-            'scripts' => array(
-                'patch' => array('@test'),
-                'test' => array('test'),
-            ),
-        ));
+        $this->processConfiguration([
+            'scripts' => [
+                'patch' => ['@test'],
+                'test' => ['test'],
+            ],
+        ]);
     }
 }

--- a/tests/ServiceContainer/ExtensionManagerTest.php
+++ b/tests/ServiceContainer/ExtensionManagerTest.php
@@ -11,7 +11,7 @@ class ExtensionManagerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->extensionManager = new ExtensionManager(array());
+        $this->extensionManager = new ExtensionManager([]);
     }
 
     public function testActivateExtensionWithClass()
@@ -19,7 +19,7 @@ class ExtensionManagerTest extends \PHPUnit_Framework_TestCase
         $this->extensionManager->activateExtension('Meteor\ServiceContainer\Test\TestExtension', null);
 
         $this->assertSame(
-            array('Meteor\ServiceContainer\Test\TestExtension'),
+            ['Meteor\ServiceContainer\Test\TestExtension'],
             $this->extensionManager->getExtensionClasses()
         );
     }
@@ -29,7 +29,7 @@ class ExtensionManagerTest extends \PHPUnit_Framework_TestCase
         $this->extensionManager->activateExtension(__DIR__.'/Fixtures/absolute_extension.php', null);
 
         $this->assertSame(
-            array('Meteor\ServiceContainer\Test\TestAbsoluteFileExtension'),
+            ['Meteor\ServiceContainer\Test\TestAbsoluteFileExtension'],
             $this->extensionManager->getExtensionClasses()
         );
     }
@@ -39,7 +39,7 @@ class ExtensionManagerTest extends \PHPUnit_Framework_TestCase
         $this->extensionManager->activateExtension('relative_extension.php', __DIR__.'/Fixtures');
 
         $this->assertSame(
-            array('Meteor\ServiceContainer\Test\TestRelativeFileExtension'),
+            ['Meteor\ServiceContainer\Test\TestRelativeFileExtension'],
             $this->extensionManager->getExtensionClasses()
         );
     }
@@ -63,7 +63,7 @@ class ExtensionManagerTest extends \PHPUnit_Framework_TestCase
     public function testGetExtension()
     {
         $extension = new TestExtension();
-        $extensionManager = new ExtensionManager(array($extension));
+        $extensionManager = new ExtensionManager([$extension]);
 
         $this->assertSame($extension, $extensionManager->getExtension('test'));
     }
@@ -76,28 +76,28 @@ class ExtensionManagerTest extends \PHPUnit_Framework_TestCase
     public function testGetExtensions()
     {
         $extension = new TestExtension();
-        $extensionManager = new ExtensionManager(array($extension));
+        $extensionManager = new ExtensionManager([$extension]);
 
-        $this->assertSame(array('test' => $extension), $extensionManager->getExtensions());
+        $this->assertSame(['test' => $extension], $extensionManager->getExtensions());
     }
 
     public function testGetExtensionClasses()
     {
         $extension = new TestExtension();
-        $extensionManager = new ExtensionManager(array($extension));
+        $extensionManager = new ExtensionManager([$extension]);
 
         $this->assertSame(
-            array('Meteor\ServiceContainer\Test\TestExtension'),
+            ['Meteor\ServiceContainer\Test\TestExtension'],
             $extensionManager->getExtensionClasses()
         );
     }
 
     public function testInitializeExtensions()
     {
-        $extension = Mockery::mock('Meteor\ServiceContainer\ExtensionInterface', array(
+        $extension = Mockery::mock('Meteor\ServiceContainer\ExtensionInterface', [
             'getConfigKey' => 'test',
-        ));
-        $extensionManager = new ExtensionManager(array($extension));
+        ]);
+        $extensionManager = new ExtensionManager([$extension]);
 
         $extension->shouldReceive('initialize')
             ->with($extensionManager)

--- a/tests/ServiceContainer/ExtensionTestCase.php
+++ b/tests/ServiceContainer/ExtensionTestCase.php
@@ -43,7 +43,7 @@ abstract class ExtensionTestCase extends \PHPUnit_Framework_TestCase
             $this->extensionManager
         );
 
-        $this->input = new ArrayInput(array());
+        $this->input = new ArrayInput([]);
         $this->output = new NullOutput();
     }
 
@@ -72,7 +72,7 @@ abstract class ExtensionTestCase extends \PHPUnit_Framework_TestCase
 
     public function createExtensions()
     {
-        return array(
+        return [
             new CliExtension(),
             new ConfigurationExtension(),
             new EventDispatcherExtension(),
@@ -90,6 +90,6 @@ abstract class ExtensionTestCase extends \PHPUnit_Framework_TestCase
             new PlatformExtension(),
             new ProcessExtension(),
             new ScriptsExtension(),
-        );
+        ];
     }
 }


### PR DESCRIPTION
- Increase minimum required PHP version to 5.6
- Updated dependencies (Symfony 3.1, etc.)
- Removed box dependency (using Phar instead)
