### PR TITLE
Ignore build metadata from PHP versions when checking requirement

### DIFF
--- a/src/Patch/Cli/Command/ApplyCommand.php
+++ b/src/Patch/Cli/Command/ApplyCommand.php
@@ -116,9 +116,9 @@ class ApplyCommand extends AbstractPatchCommand
     {
         // Check if the current version has metadata in it
         // example : 5.6.0-1ubuntu3.25
-        if (count(explode('-', $version)) > 1) {
-            $versionWithMetadata = explode('-', $version);
-            $version = $versionWithMetadata[0];
+        $metadataPos = strpos($version, '-');
+        if ($metadataPos !== false) {
+            $version = substr($version, 0, $metadataPos);
         }
 
         $this->phpVersion = $version;

--- a/src/Patch/Cli/Command/ApplyCommand.php
+++ b/src/Patch/Cli/Command/ApplyCommand.php
@@ -88,7 +88,7 @@ class ApplyCommand extends AbstractPatchCommand
         $this->eventDispatcher = $eventDispatcher;
         $this->scriptRunner = $scriptRunner;
         $this->logger = $logger;
-        $this->phpVersion = $phpVersion;
+        $this->setPhpVersion($phpVersion);
 
         parent::__construct($name, $config, $io, $platform);
     }
@@ -114,7 +114,23 @@ class ApplyCommand extends AbstractPatchCommand
      */
     public function setPhpVersion($version)
     {
+        // Check if the current version has metadata in it
+        // example : 5.6.0-1ubuntu3.25
+        if (count(explode('-', $version)) > 1) {
+            $versionWithMetadata = explode('-', $version);
+            $version = $versionWithMetadata[0];
+        }
+
         $this->phpVersion = $version;
+    }
+
+    /**
+     * Returns the current set php version
+     * @return string|void
+     */
+    public function getPhpVersion()
+    {
+        return $this->phpVersion;
     }
 
     /**
@@ -151,8 +167,10 @@ class ApplyCommand extends AbstractPatchCommand
     }
 
     /**
-     * @param InputInterface $input
+     * @param InputInterface  $input
      * @param OutputInterface $output
+     *
+     * @return int|null
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/tests/Patch/Cli/Command/ApplyCommandTest.php
+++ b/tests/Patch/Cli/Command/ApplyCommandTest.php
@@ -225,6 +225,87 @@ class ApplyCommandTest extends CommandTestCase
         ]);
     }
 
+    public function testAppliesPatchWithPhpVersionMetadata()
+    {
+        $workingDir = vfsStream::url('root/patch');
+        $installDir = vfsStream::url('root/install');
+
+        $config = [
+            'name' => 'test',
+            'package' => [
+                "php" => ">=5.3.2"
+            ],
+        ];
+        $this->command->setConfiguration($config);
+        $this->command->setPhpVersion('5.6.0-1ubuntu3.25');
+
+        $this->platform->shouldReceive('setInstallDir')
+            ->with($installDir)
+            ->once();
+
+        $this->scriptRunner->shouldReceive('setWorkingDir')
+            ->with($installDir)
+            ->once();
+
+        $this->logger->shouldReceive('enable')
+            ->once();
+
+        $this->locker->shouldReceive('lock')
+            ->with($installDir)
+            ->once();
+
+        $this->eventDispatcher->shouldReceive('dispatch')
+            ->with(PatchEvents::PRE_APPLY, Mockery::any())
+            ->once();
+
+        $tasks = [
+            new \stdClass(),
+            new \stdClass(),
+        ];
+        $this->strategy->shouldReceive('apply')
+            ->with($workingDir, $installDir, Mockery::any())
+            ->andReturn($tasks)
+            ->once();
+
+        $this->taskBus->shouldReceive('run')
+            ->with($tasks[0], $config)
+            ->andReturn(true)
+            ->once();
+
+        $this->taskBus->shouldReceive('run')
+            ->with($tasks[1], $config)
+            ->andReturn(true)
+            ->once();
+
+        $this->eventDispatcher->shouldReceive('dispatch')
+            ->with(PatchEvents::POST_APPLY, Mockery::any())
+            ->once();
+
+        $this->locker->shouldReceive('unlock')
+            ->with($installDir)
+            ->once();
+
+        $this->tester->execute([
+            '--working-dir' => $workingDir,
+            '--install-dir' => $installDir,
+        ]);
+    }
+
+    public function testPhpVersionConstraintWithVersionMetadata()
+    {
+        $config = [
+            'name' => 'test',
+            'package' => [
+                "php" => ">=5.3.2"
+            ],
+        ];
+
+        $this->command->setConfiguration($config);
+        $this->command->setPhpVersion('5.6.0-1ubuntu3.25');
+        
+        $this->assertEquals('5.6.0', $this->command->getPhpVersion());
+    }
+
     /**
      * @expectedException Meteor\Patch\Exception\PhpVersionException
      * @expectedExceptionMessage Your PHP version (5.4.0) is not sufficient enough for the package "package/second", which requires >=5.6

--- a/tests/Patch/Cli/Command/ApplyCommandTest.php
+++ b/tests/Patch/Cli/Command/ApplyCommandTest.php
@@ -302,7 +302,7 @@ class ApplyCommandTest extends CommandTestCase
 
         $this->command->setConfiguration($config);
         $this->command->setPhpVersion('5.6.0-1ubuntu3.25');
-        
+
         $this->assertEquals('5.6.0', $this->command->getPhpVersion());
     }
 


### PR DESCRIPTION
Fixes an issue where php versions have metadata in them ( example `5.6.0-1ubuntu3.25` ). 
This pull request fixes this issue by ignoring the metadata information when setting the php version in `ApplyCommand`

Fixes #56 
