### PR TITLE
Allow autoload paths to be registered with Meteor.

### DIFF
--- a/bin/meteor
+++ b/bin/meteor
@@ -32,4 +32,4 @@ if (ini_get('date.timezone') === '') {
 }
 
 $factory = new ApplicationFactory();
-$factory->createApplication()->run();
+$factory->createApplication($loader)->run();

--- a/docs/_docs/autoload.md
+++ b/docs/_docs/autoload.md
@@ -1,0 +1,28 @@
+---
+title: Autoload paths
+layout: docs
+toc: true
+---
+It is possible to add additional autoload paths to the Meteor class loader. This may be useful when writing custom migration base classes or helpers.
+
+## Composer paths
+
+The `composer` path type will load the `composer.json` of the specified Composer packages and add any `psr-0`, `psr-4` or `classmap` paths it finds.
+
+```json
+"autoload": {
+    "composer": ["jadu/test"]
+}
+```
+
+## PSR-4 paths
+
+The `psr-4` path type will add the given prefix and paths to the class loader.
+
+```json
+"autoload": {
+    "psr-4": {
+        "Jadu\\": "jadu/"
+    }
+}
+```

--- a/docs/_docs/autoload.md
+++ b/docs/_docs/autoload.md
@@ -26,3 +26,5 @@ The `psr-4` path type will add the given prefix and paths to the class loader.
     }
 }
 ```
+
+The paths added to the class loader will be prepended with the package root path, e.g. `/path/to/package/to_patch`.

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -2,6 +2,8 @@
 
 namespace Meteor;
 
+use Composer\Autoload\ClassLoader;
+use Meteor\Autoload\ServiceContainer\AutoloadExtension;
 use Meteor\Cli\Application;
 use Meteor\Cli\ServiceContainer\CliExtension;
 use Meteor\Configuration\ConfigurationLoader;
@@ -45,6 +47,7 @@ class ApplicationFactory
     protected function getDefaultExtensions()
     {
         return [
+            new AutoloadExtension(),
             new CliExtension(),
             new ConfigurationExtension(),
             new EventDispatcherExtension(),
@@ -63,14 +66,16 @@ class ApplicationFactory
     }
 
     /**
+     * @param ClassLoader $classLoader
+     *
      * @return Application
      */
-    public function createApplication()
+    public function createApplication(ClassLoader $classLoader)
     {
         $extensionManager = $this->createExtensionManager();
         $configurationLoader = $this->createConfigurationLoader($extensionManager);
 
-        return new Application($this->getName(), $this->getVersion(), $configurationLoader, $extensionManager);
+        return new Application($this->getName(), $this->getVersion(), $configurationLoader, $extensionManager, $classLoader);
     }
 
     /**

--- a/src/Autoload/ServiceContainer/AutoloadExtension.php
+++ b/src/Autoload/ServiceContainer/AutoloadExtension.php
@@ -106,6 +106,7 @@ class AutoloadExtension extends ExtensionBase implements ExtensionInterface
     /**
      * @param array|string $paths
      * @param string $workingDir
+     *
      * @return array
      */
     private function normalizePaths($paths, $rootPath)

--- a/src/Autoload/ServiceContainer/AutoloadExtension.php
+++ b/src/Autoload/ServiceContainer/AutoloadExtension.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Meteor\Autoload\ServiceContainer;
+
+use Meteor\Cli\Application;
+use Meteor\Package\PackageConstants;
+use Meteor\ServiceContainer\ExtensionBase;
+use Meteor\ServiceContainer\ExtensionInterface;
+use Meteor\ServiceContainer\ExtensionManager;
+use RuntimeException;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AutoloadExtension extends ExtensionBase implements ExtensionInterface
+{
+    const SERVICE_CLASS_LOADER = 'autoload.class_loader';
+
+    /**
+     * Returns the extension config key.
+     *
+     * @return string
+     */
+    public function getConfigKey()
+    {
+        return 'autoload';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize(ExtensionManager $extensionManager)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(ArrayNodeDefinition $builder)
+    {
+        $builder
+            ->normalizeKeys(false)
+            ->children()
+                ->arrayNode('composer')
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('psr-4')
+                    ->prototype('array')
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->then(function ($value) {
+                                return [$value];
+                            })
+                        ->end()
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(ContainerBuilder $container, array $config)
+    {
+        $workingDir = $container->getParameter(Application::PARAMETER_WORKING_DIR);
+        $classLoader = $container->get(self::SERVICE_CLASS_LOADER);
+
+        if (isset($config['composer'])) {
+            foreach ($config['composer'] as $packageName) {
+                $composerJsonPath = $workingDir.'/'.PackageConstants::PATCH_DIR.'/vendor/'.$packageName.'/composer.json';
+                if (!file_exists($composerJsonPath)) {
+                    throw new RuntimeException(sprintf('Unable to find "%s" to fetch autoload paths', $composerJsonPath));
+                }
+
+                // Parse composer.json to find autoload paths
+                $json = json_decode(file_get_contents($composerJsonPath), true);
+                if (isset($json['autoload'])) {
+                    if (isset($json['autoload']['psr-0'])) {
+                        foreach ($json['autoload']['psr-0'] as $prefix => $paths) {
+                            $classLoader->add($prefix, $paths);
+                        }
+                    }
+
+                    if (isset($json['autoload']['psr-4'])) {
+                        foreach ($json['autoload']['psr-4'] as $prefix => $paths) {
+                            $classLoader->addPsr4($prefix, $paths);
+                        }
+                    }
+
+                    if (isset($json['autoload']['classmap'])) {
+                        $classLoader->addClassMap($json['autoload']['classmap']);
+                    }
+                }
+            }
+        }
+
+        if (isset($config['psr-4'])) {
+            foreach ($config['psr-4'] as $namespace => $paths) {
+                $classLoader->addPsr4($namespace, $paths);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+    }
+}

--- a/src/Configuration/ConfigurationWriter.php
+++ b/src/Configuration/ConfigurationWriter.php
@@ -2,6 +2,8 @@
 
 namespace Meteor\Configuration;
 
+use RuntimeException;
+
 class ConfigurationWriter
 {
     /**

--- a/src/Migrations/Cli/Command/ExecuteMigrationCommand.php
+++ b/src/Migrations/Cli/Command/ExecuteMigrationCommand.php
@@ -48,7 +48,7 @@ class ExecuteMigrationCommand extends AbstractPatchCommand
 
     protected function configure()
     {
-        $help = <<<EOT
+        $help = <<<'EOT'
 The <info>%command.name%</info> command executes a single migration version up or down manually:
 
     <info>%command.full_name% jadu/cms YYYYMMDDHHMMSS</info>

--- a/src/Migrations/Cli/Command/MigrateCommand.php
+++ b/src/Migrations/Cli/Command/MigrateCommand.php
@@ -48,7 +48,7 @@ class MigrateCommand extends AbstractPatchCommand
 
     protected function configure()
     {
-        $help = <<<EOT
+        $help = <<<'EOT'
 The <info>%command.name%</info> command executes a migration to a specified version or the latest available version:
 
     <info>%command.full_name%</>

--- a/src/Migrations/Cli/Command/VersionCommand.php
+++ b/src/Migrations/Cli/Command/VersionCommand.php
@@ -40,7 +40,7 @@ class VersionCommand extends AbstractPatchCommand
 
     protected function configure()
     {
-        $help = <<<EOT
+        $help = <<<'EOT'
 The <info>%command.name%</info> command allows you to manually add, delete or synchronize migration versions:
 
     <info>%command.full_name% jadu/cms YYYYMMDDHHMMSS --add</info>
@@ -107,7 +107,7 @@ EOT;
             }
         }
 
-        $markMigrated = (boolean) $input->getOption('add');
+        $markMigrated = (bool) $input->getOption('add');
 
         if ($this->io->getOption('all') === true) {
             if ($markMigrated) {

--- a/src/Migrations/Configuration/AbstractConfiguration.php
+++ b/src/Migrations/Configuration/AbstractConfiguration.php
@@ -34,8 +34,8 @@ abstract class AbstractConfiguration extends DoctrineConfiguration
      * Register a single migration version to be executed by a AbstractMigration
      * class.
      *
-     * @param string $version The version of the migration in the format YYYYMMDDHHMMSS.
-     * @param string $class   The migration class to execute for the version.
+     * @param string $version The version of the migration in the format YYYYMMDDHHMMSS
+     * @param string $class   The migration class to execute for the version
      *
      * @return Version
      *

--- a/src/Migrations/Configuration/ConfigurationFactory.php
+++ b/src/Migrations/Configuration/ConfigurationFactory.php
@@ -3,6 +3,7 @@
 namespace Meteor\Migrations\Configuration;
 
 use Doctrine\DBAL\Migrations\OutputWriter;
+use InvalidArgumentException;
 use Meteor\IO\IOInterface;
 use Meteor\Migrations\Connection\ConnectionFactory;
 use Meteor\Migrations\MigrationsConstants;

--- a/src/Migrations/Outputter/StatusOutputter.php
+++ b/src/Migrations/Outputter/StatusOutputter.php
@@ -2,7 +2,9 @@
 
 namespace Meteor\Migrations\Outputter;
 
+use InvalidArgumentException;
 use Meteor\IO\IOInterface;
+use Meteor\Migrations\Configuration\AbstractConfiguration;
 use Meteor\Migrations\Configuration\ConfigurationFactory;
 use Meteor\Migrations\MigrationsConstants;
 

--- a/src/Migrations/Version/FileMigrationVersion.php
+++ b/src/Migrations/Version/FileMigrationVersion.php
@@ -22,7 +22,7 @@ class FileMigrationVersion extends Version
      */
     public function __construct(Configuration $configuration, $version, $class, SchemaDiffProviderInterface $schemaProvider = null, FileMigrationVersionStorage $versionStorage = null)
     {
-        parent::__construct($configuration, $version, $class, $schemaProvider);
+        parent::__construct($configuration, $version, $class);
 
         $this->versionStorage = $versionStorage;
     }

--- a/src/Package/PackageCreator.php
+++ b/src/Package/PackageCreator.php
@@ -145,7 +145,7 @@ class PackageCreator
             $this->io->debug(sprintf('Creating archive <info>%s</>', $outputFile));
             $this->packageArchiver->archive($tempDir, $outputFile, $fileName);
 
-            $this->io->success(sprintf('Package created successfully', $outputFile));
+            $this->io->success('Package created successfully');
             $this->io->text(sprintf('The package is located at: <info>%s</>', realpath($outputFile)));
             $this->io->newLine();
         } catch (CombinedPackageDependenciesException $exception) {

--- a/src/Patch/Cli/Command/ApplyCommand.php
+++ b/src/Patch/Cli/Command/ApplyCommand.php
@@ -125,7 +125,8 @@ class ApplyCommand extends AbstractPatchCommand
     }
 
     /**
-     * Returns the current set php version
+     * Returns the current set php version.
+     *
      * @return string|void
      */
     public function getPhpVersion()

--- a/src/Patch/Task/DeleteBackup.php
+++ b/src/Patch/Task/DeleteBackup.php
@@ -5,7 +5,7 @@ namespace Meteor\Patch\Task;
 class DeleteBackup
 {
     /**
-     * @var sting
+     * @var string
      */
     public $backupDir;
 

--- a/src/Permissions/Permission.php
+++ b/src/Permissions/Permission.php
@@ -47,7 +47,7 @@ class Permission
      * @param string $pattern
      * @param array $modes
      *
-     * @return FilePermission
+     * @return Permission
      */
     public static function create($pattern, array $modes)
     {

--- a/src/Platform/Unix/InstallConfigLoader.php
+++ b/src/Platform/Unix/InstallConfigLoader.php
@@ -11,7 +11,7 @@ class InstallConfigLoader
     /**
      * @param string $path
      *
-     * @return JaduInstallConfig
+     * @return InstallConfig
      */
     public function load($path)
     {

--- a/src/Platform/Unix/UnixPlatform.php
+++ b/src/Platform/Unix/UnixPlatform.php
@@ -89,7 +89,7 @@ class UnixPlatform implements PlatformInterface
     /**
      * @param string $path
      *
-     * @return octal
+     * @return int
      */
     private function getDefaultMode($path)
     {

--- a/src/ServiceContainer/ExtensionBase.php
+++ b/src/ServiceContainer/ExtensionBase.php
@@ -2,7 +2,7 @@
 
 namespace Meteor\ServiceContainer;
 
-abstract class ExtensionBase
+abstract class ExtensionBase implements ExtensionInterface
 {
     /**
      * {@inheritdoc}

--- a/tests/ApplicationFactoryTest.php
+++ b/tests/ApplicationFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Meteor;
 
+use Composer\Autoload\ClassLoader;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -13,7 +14,7 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $factory = new ApplicationFactory();
-        $this->application = $factory->createApplication();
+        $this->application = $factory->createApplication(new ClassLoader());
         $this->application->setAutoExit(false);
 
         $this->output = new StreamOutput(fopen('php://memory', 'w', false));

--- a/tests/Autoload/ServiceContainer/AutoloadExtensionTest.php
+++ b/tests/Autoload/ServiceContainer/AutoloadExtensionTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Meteor\Autoload\ServiceContainer;
+
+use Meteor\ServiceContainer\ExtensionTestCase;
+use org\bovigo\vfs\vfsStream;
+
+class AutoloadExtensionTest extends ExtensionTestCase
+{
+    public function testAddsComposerPackagesWithPsr0()
+    {
+        $composerJson = <<<'JSON'
+{
+    "name": "test/test",
+    "autoload": {
+        "psr-0": {
+            "Test_": "src/"
+        }
+    }
+}
+JSON;
+
+        vfsStream::setup('root', null, [
+            'to_patch' => [
+                'vendor' => [
+                    'test' => [
+                        'test' => [
+                            'composer.json' => $composerJson,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container = $this->loadContainer([
+            'autoload' => [
+                'composer' => ['test/test'],
+            ],
+        ], vfsStream::url('root'));
+
+        $prefixes = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getPrefixes();
+
+        $this->assertArraySubset([
+            'Test_' => ['src/'],
+        ], $prefixes);
+    }
+
+    public function testAddsComposerPackagesWithPsr4()
+    {
+        $composerJson = <<<'JSON'
+{
+    "name": "test/test",
+    "autoload": {
+        "psr-4": {
+            "Test\\": "src/"
+        }
+    }
+}
+JSON;
+
+        vfsStream::setup('root', null, [
+            'to_patch' => [
+                'vendor' => [
+                    'test' => [
+                        'test' => [
+                            'composer.json' => $composerJson,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container = $this->loadContainer([
+            'autoload' => [
+                'composer' => ['test/test'],
+            ],
+        ], vfsStream::url('root'));
+
+        $prefixes = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getPrefixesPsr4();
+
+        $this->assertArraySubset([
+            'Test\\' => ['src/'],
+        ], $prefixes);
+    }
+
+    public function testAddsComposerPackagesWithClassMap()
+    {
+        $composerJson = <<<'JSON'
+{
+    "name": "test/test",
+    "autoload": {
+        "classmap": ["file.php"]
+    }
+}
+JSON;
+
+        vfsStream::setup('root', null, [
+            'to_patch' => [
+                'vendor' => [
+                    'test' => [
+                        'test' => [
+                            'composer.json' => $composerJson,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container = $this->loadContainer([
+            'autoload' => [
+                'composer' => ['test/test'],
+            ],
+        ], vfsStream::url('root'));
+
+        $classMap = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getClassMap();
+
+        $this->assertArraySubset(['file.php'], $classMap);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testThrowsExceptionWhenComposerPackageNotFound()
+    {
+        vfsStream::setup('root');
+
+        $container = $this->loadContainer([
+            'autoload' => [
+                'composer' => ['test/test'],
+            ],
+        ], vfsStream::url('root'));
+    }
+
+    public function testAddsPsr4Path()
+    {
+        $container = $this->loadContainer([
+            'autoload' => [
+                'psr-4' => [
+                    'Jadu\\' => 'src/',
+                ],
+            ],
+        ]);
+
+        $prefixes = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getPrefixesPsr4();
+
+        $this->assertArraySubset([
+            'Jadu\\' => ['src/'],
+        ], $prefixes);
+    }
+
+    public function testAddsPsr4Paths()
+    {
+        $container = $this->loadContainer([
+            'autoload' => [
+                'psr-4' => [
+                    'Jadu\\' => ['src/', 'tests/'],
+                ],
+            ],
+        ]);
+
+        $prefixes = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getPrefixesPsr4();
+
+        $this->assertArraySubset([
+            'Jadu\\' => ['src/', 'tests/'],
+        ], $prefixes);
+    }
+
+    public function testAutoloadComposerPackages()
+    {
+        $config = $this->processConfiguration([
+            'autoload' => [
+                'composer' => [
+                    'spacecraft/migrations',
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            'spacecraft/migrations',
+        ], $config['autoload']['composer']);
+    }
+
+    public function testAutoloadPsr4Paths()
+    {
+        $config = $this->processConfiguration([
+            'autoload' => [
+                'psr-4' => [
+                    'Jadu\\' => ['src/'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            'Jadu\\' => ['src/'],
+        ], $config['autoload']['psr-4']);
+    }
+}

--- a/tests/Autoload/ServiceContainer/AutoloadExtensionTest.php
+++ b/tests/Autoload/ServiceContainer/AutoloadExtensionTest.php
@@ -41,7 +41,7 @@ JSON;
         $prefixes = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getPrefixes();
 
         $this->assertArraySubset([
-            'Test_' => ['src/'],
+            'Test_' => [vfsStream::url('root/to_patch/vendor/test/test/src/')],
         ], $prefixes);
     }
 
@@ -79,7 +79,7 @@ JSON;
         $prefixes = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getPrefixesPsr4();
 
         $this->assertArraySubset([
-            'Test\\' => ['src/'],
+            'Test\\' => [vfsStream::url('root/to_patch/vendor/test/test/src/')],
         ], $prefixes);
     }
 
@@ -114,7 +114,7 @@ JSON;
 
         $classMap = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getClassMap();
 
-        $this->assertArraySubset(['file.php'], $classMap);
+        $this->assertArraySubset([vfsStream::url('root/to_patch/vendor/test/test/file.php')], $classMap);
     }
 
     /**
@@ -139,12 +139,12 @@ JSON;
                     'Jadu\\' => 'src/',
                 ],
             ],
-        ]);
+        ], '/path/to/working');
 
         $prefixes = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getPrefixesPsr4();
 
         $this->assertArraySubset([
-            'Jadu\\' => ['src/'],
+            'Jadu\\' => ['/path/to/working/src/'],
         ], $prefixes);
     }
 
@@ -156,12 +156,12 @@ JSON;
                     'Jadu\\' => ['src/', 'tests/'],
                 ],
             ],
-        ]);
+        ], '/path/to/working');
 
         $prefixes = $container->get(AutoloadExtension::SERVICE_CLASS_LOADER)->getPrefixesPsr4();
 
         $this->assertArraySubset([
-            'Jadu\\' => ['src/', 'tests/'],
+            'Jadu\\' => ['/path/to/working/src/', '/path/to/working/tests/'],
         ], $prefixes);
     }
 

--- a/tests/BackwardsCompatibility/Config/InstallConfigLoaderTest.php
+++ b/tests/BackwardsCompatibility/Config/InstallConfigLoaderTest.php
@@ -15,7 +15,7 @@ class InstallConfigLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoad()
     {
-        $installConf = <<<CONF
+        $installConf = <<<'CONF'
 JADU_VERSION="1.12"
 VERBOSE=
 GNU="yes"
@@ -84,7 +84,7 @@ CONF;
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unable to find install.conf file
      */
     public function testLoadThrowsExceptionWhenFileDoesNotExist()
@@ -95,7 +95,7 @@ CONF;
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unable to parse install.conf file
      */
     public function testLoadThrowsExceptionWhenFileCannotBeParsed()

--- a/tests/Cli/Command/CommandTestCase.php
+++ b/tests/Cli/Command/CommandTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Meteor\Cli\Command;
 
+use Composer\Autoload\ClassLoader;
 use Meteor\Cli\Application;
 use Meteor\Configuration\ConfigurationLoader;
 use Meteor\ServiceContainer\ExtensionManager;
@@ -16,9 +17,10 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
     {
         $extensionManager = new ExtensionManager([]);
         $configurationLoader = new ConfigurationLoader($extensionManager);
+        $classLoader = new ClassLoader();
 
         $this->command = $this->createCommand();
-        $this->application = new Application('meteor', '2.0.0', $configurationLoader, $extensionManager);
+        $this->application = new Application('meteor', '2.0.0', $configurationLoader, $extensionManager, $classLoader);
         $this->application->add($this->command);
 
         $this->tester = new CommandTester($this->command);

--- a/tests/Cli/Command/CommandTester.php
+++ b/tests/Cli/Command/CommandTester.php
@@ -18,7 +18,7 @@ class CommandTester
     /**
      * Constructor.
      *
-     * @param Command $command A Command instance to test.
+     * @param Command $command A Command instance to test
      */
     public function __construct(Command $command)
     {

--- a/tests/Configuration/ConfigurationLoaderTest.php
+++ b/tests/Configuration/ConfigurationLoaderTest.php
@@ -79,7 +79,7 @@ class ConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testParseReturnsConfigAsArray()
     {
-        $json = <<<JSON
+        $json = <<<'JSON'
 {
     "name": "jadu/xfp",
     "migrations": {
@@ -103,7 +103,7 @@ JSON;
     }
 
     /**
-     * @expectedException Meteor\Configuration\Exception\ConfigurationLoadingException
+     * @expectedException \Meteor\Configuration\Exception\ConfigurationLoadingException
      */
     public function testParseThrowsExceptionWhenFileCannotBeRead()
     {
@@ -113,7 +113,7 @@ JSON;
     }
 
     /**
-     * @expectedException Meteor\Configuration\Exception\ConfigurationLoadingException
+     * @expectedException \Meteor\Configuration\Exception\ConfigurationLoadingException
      */
     public function testParseThrowsExceptionWhenJsonCannotBeParsed()
     {
@@ -126,7 +126,7 @@ JSON;
 
     public function testLoad()
     {
-        $json = <<<JSON
+        $json = <<<'JSON'
 {
     "name": "jadu/xfp"
 }
@@ -148,7 +148,7 @@ JSON;
 
     public function testLoadCombined()
     {
-        $json = <<<JSON
+        $json = <<<'JSON'
 {
     "name": "jadu/xfp",
     "combined": [
@@ -180,7 +180,7 @@ JSON;
 
     public function testLoadIgnoresUnrecognisedOptionsWhenNotStrict()
     {
-        $json = <<<JSON
+        $json = <<<'JSON'
 {
     "name": "jadu/xfp",
     "test_unrecognised": true
@@ -202,7 +202,7 @@ JSON;
     }
 
     /**
-     * @expectedException Meteor\Configuration\Exception\ConfigurationLoadingException
+     * @expectedException \Meteor\Configuration\Exception\ConfigurationLoadingException
      */
     public function testCannotProcessBeforeTreeIsBuild()
     {

--- a/tests/Configuration/ConfigurationWriterTest.php
+++ b/tests/Configuration/ConfigurationWriterTest.php
@@ -27,7 +27,7 @@ class ConfigurationWriterTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $expectedJson = <<<JSON
+        $expectedJson = <<<'JSON'
 {
     "name": "jadu/xfp",
     "package": {
@@ -53,7 +53,7 @@ JSON;
             'migrations' => null,
         ];
 
-        $expectedJson = <<<JSON
+        $expectedJson = <<<'JSON'
 {
     "name": "jadu/xfp"
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -6,7 +6,6 @@ use Meteor\Filesystem\Finder\FinderFactory;
 use Meteor\IO\NullIO;
 use Mockery;
 use org\bovigo\vfs\vfsStream;
-use RuntimeException;
 use Symfony\Component\Finder\Finder;
 
 class FilesystemTest extends \PHPUnit_Framework_TestCase
@@ -71,7 +70,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testEnsureDirectoryExistsThrowsExceptionIfFileExists()
     {

--- a/tests/Logger/LoggerTest.php
+++ b/tests/Logger/LoggerTest.php
@@ -37,7 +37,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
         $this->logger->log(['test', 'hello', 'goodbye', '']);
 
-        $expected = <<<LOG
+        $expected = <<<'LOG'
 [2016-07-01T08:00:00+00:00/32.76MB] test
 [2016-07-01T08:00:00+00:00/32.76MB] hello
 [2016-07-01T08:00:00+00:00/32.76MB] goodbye
@@ -56,7 +56,7 @@ LOG;
         $this->logger->log('goodbye');
         $this->logger->log('');
 
-        $expected = <<<LOG
+        $expected = <<<'LOG'
 [2016-07-01T08:00:00+00:00/32.76MB] test
 [2016-07-01T08:00:00+00:00/32.76MB] hello
 [2016-07-01T08:00:00+00:00/32.76MB] goodbye
@@ -72,7 +72,7 @@ LOG;
 
         $this->logger->log("this\nis\na\ntest");
 
-        $expected = <<<LOG
+        $expected = <<<'LOG'
 [2016-07-01T08:00:00+00:00/32.76MB] this
 [2016-07-01T08:00:00+00:00/32.76MB] is
 [2016-07-01T08:00:00+00:00/32.76MB] a
@@ -88,7 +88,7 @@ LOG;
 
         $this->logger->log('<error>Error</>');
 
-        $expected = <<<LOG
+        $expected = <<<'LOG'
 [2016-07-01T08:00:00+00:00/32.76MB] Error
 LOG;
 
@@ -101,7 +101,7 @@ LOG;
 
         $this->logger->log('test     ');
 
-        $expected = <<<LOG
+        $expected = <<<'LOG'
 [2016-07-01T08:00:00+00:00/32.76MB] test
 LOG;
 

--- a/tests/Migrations/Connection/Configuration/Loader/SystemConfigurationLoaderTest.php
+++ b/tests/Migrations/Connection/Configuration/Loader/SystemConfigurationLoaderTest.php
@@ -15,7 +15,7 @@ class SystemConfigurationLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadsFromSystemXml()
     {
-        $systemXml = <<<XML
+        $systemXml = <<<'XML'
 <?xml version="1.0" encoding="utf-8" ?>
 <system xmlns:config="http://www.jadu.co.uk/schema/config">
     <db_host>localhost</db_host>
@@ -45,7 +45,7 @@ XML;
 
     public function testUsesPdoMysqlForMysql()
     {
-        $systemXml = <<<XML
+        $systemXml = <<<'XML'
 <?xml version="1.0" encoding="utf-8" ?>
 <system xmlns:config="http://www.jadu.co.uk/schema/config">
     <db_host>localhost</db_host>
@@ -75,7 +75,7 @@ XML;
 
     public function testUsesSqlsrvForMssql()
     {
-        $systemXml = <<<XML
+        $systemXml = <<<'XML'
 <?xml version="1.0" encoding="utf-8" ?>
 <system xmlns:config="http://www.jadu.co.uk/schema/config">
     <db_host>localhost</db_host>
@@ -105,7 +105,7 @@ XML;
 
     public function testLoadDoesNotReturnConfigurationWhenDsnUsed()
     {
-        $systemXml = <<<XML
+        $systemXml = <<<'XML'
 <?xml version="1.0" encoding="utf-8" ?>
 <system xmlns:config="http://www.jadu.co.uk/schema/config">
     <db_host>localhost</db_host>

--- a/tests/Migrations/Generator/MigrationGeneratorTest.php
+++ b/tests/Migrations/Generator/MigrationGeneratorTest.php
@@ -2,7 +2,6 @@
 
 namespace Meteor\Migrations\Generator;
 
-use InvalidArgumentException;
 use org\bovigo\vfs\vfsStream;
 
 class MigrationGeneratorTest extends \PHPUnit_Framework_TestCase
@@ -50,7 +49,7 @@ PHP;
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testGenerateThrowsExceptionWhenMigrationsDirectoryDoesNotExist()
     {

--- a/tests/Package/Combined/CombinedPackageDependencyCheckerTest.php
+++ b/tests/Package/Combined/CombinedPackageDependencyCheckerTest.php
@@ -39,7 +39,7 @@ class CombinedPackageDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Combined\Exception\CombinedPackageDependenciesException
+     * @expectedException \Meteor\Package\Combined\Exception\CombinedPackageDependenciesException
      */
     public function testCheckThrowsExceptionWhenRequiredPackageMissing()
     {
@@ -55,7 +55,7 @@ class CombinedPackageDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Combined\Exception\CombinedPackageDependenciesException
+     * @expectedException \Meteor\Package\Combined\Exception\CombinedPackageDependenciesException
      */
     public function testChecksRequirementsRecursively()
     {
@@ -108,7 +108,7 @@ class CombinedPackageDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Combined\Exception\CombinedPackageDependenciesException
+     * @expectedException \Meteor\Package\Combined\Exception\CombinedPackageDependenciesException
      */
     public function testCheckThrowsExceptionWhenVersionRequirementIsNotMet()
     {
@@ -138,7 +138,7 @@ class CombinedPackageDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Combined\Exception\CombinedPackageDependenciesException
+     * @expectedException \Meteor\Package\Combined\Exception\CombinedPackageDependenciesException
      */
     public function testChecksVersionRequirementsRecursively()
     {

--- a/tests/Package/Composer/ComposerDependencyCheckerTest.php
+++ b/tests/Package/Composer/ComposerDependencyCheckerTest.php
@@ -61,7 +61,7 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Composer\Exception\ComposerDependenciesException
+     * @expectedException \Meteor\Package\Composer\Exception\ComposerDependenciesException
      */
     public function testGetRequirementsThrowsExceptionWhenComposerJsonCannotBeParsed()
     {
@@ -160,7 +160,7 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Composer\Exception\ComposerDependenciesException
+     * @expectedException \Meteor\Package\Composer\Exception\ComposerDependenciesException
      */
     public function testCheckThrowsExceptionWhenComposerLockCannotBeParsed()
     {
@@ -183,7 +183,7 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Composer\Exception\ComposerDependenciesException
+     * @expectedException \Meteor\Package\Composer\Exception\ComposerDependenciesException
      */
     public function testCheckThrowsExceptionWhenHasRequiredPackagesAndLockFileMissing()
     {
@@ -202,7 +202,7 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Composer\Exception\ComposerDependenciesException
+     * @expectedException \Meteor\Package\Composer\Exception\ComposerDependenciesException
      */
     public function testCheckThrowsExceptionWhenRequiredPackageMissingFromLockFile()
     {
@@ -225,7 +225,7 @@ class ComposerDependencyCheckerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Composer\Exception\ComposerDependenciesException
+     * @expectedException \Meteor\Package\Composer\Exception\ComposerDependenciesException
      */
     public function testCheckThrowsExceptionWhenVersionInLockFileDoesNotSatisfyRequiredPackageConstraint()
     {

--- a/tests/Package/PackageNameResolverTest.php
+++ b/tests/Package/PackageNameResolverTest.php
@@ -73,7 +73,7 @@ class PackageNameResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testResolveThrowsExceptionWhenVersionFileCannotBeFound()
     {

--- a/tests/Package/Provider/GoogleDrive/GoogleDrivePackageProviderTest.php
+++ b/tests/Package/Provider/GoogleDrive/GoogleDrivePackageProviderTest.php
@@ -37,7 +37,7 @@ class GoogleDrivePackageProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Provider\Exception\PackageNotFoundException
+     * @expectedException \Meteor\Package\Provider\Exception\PackageNotFoundException
      */
     public function testDownloadThrowsExceptionWhenPackageFolderNotConfigured()
     {
@@ -45,7 +45,7 @@ class GoogleDrivePackageProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\Package\Provider\Exception\PackageNotFoundException
+     * @expectedException \Meteor\Package\Provider\Exception\PackageNotFoundException
      */
     public function testDownloadThrowsExceptionWhenPackageNotDownloaded()
     {

--- a/tests/Patch/Cli/Command/ApplyCommandTest.php
+++ b/tests/Patch/Cli/Command/ApplyCommandTest.php
@@ -117,7 +117,7 @@ class ApplyCommandTest extends CommandTestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testThrowsExceptionWhenWorkingDirIsTheSameAsTheInstallDir()
     {
@@ -201,7 +201,7 @@ class ApplyCommandTest extends CommandTestCase
     }
 
     /**
-     * @expectedException Meteor\Patch\Exception\PhpVersionException
+     * @expectedException \Meteor\Patch\Exception\PhpVersionException
      * @expectedExceptionMessage Your PHP version (5.6.0) is not sufficient enough for the package "test", which requires >=7
      */
     public function testPhpVersionConstraint()
@@ -233,7 +233,7 @@ class ApplyCommandTest extends CommandTestCase
         $config = [
             'name' => 'test',
             'package' => [
-                "php" => ">=5.3.2"
+                'php' => '>=5.3.2',
             ],
         ];
         $this->command->setConfiguration($config);
@@ -296,7 +296,7 @@ class ApplyCommandTest extends CommandTestCase
         $config = [
             'name' => 'test',
             'package' => [
-                "php" => ">=5.3.2"
+                'php' => '>=5.3.2',
             ],
         ];
 
@@ -307,7 +307,7 @@ class ApplyCommandTest extends CommandTestCase
     }
 
     /**
-     * @expectedException Meteor\Patch\Exception\PhpVersionException
+     * @expectedException \Meteor\Patch\Exception\PhpVersionException
      * @expectedExceptionMessage Your PHP version (5.4.0) is not sufficient enough for the package "package/second", which requires >=5.6
      */
     public function testCombinedPhpVersionConstraint()

--- a/tests/Patch/Cli/Command/RollbackCommandTest.php
+++ b/tests/Patch/Cli/Command/RollbackCommandTest.php
@@ -211,7 +211,7 @@ class RollbackCommandTest extends CommandTestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testThrowsExceptionWhenWorkingDirIsTheSameAsTheInstallDir()
     {

--- a/tests/Patch/Lock/LockerTest.php
+++ b/tests/Patch/Lock/LockerTest.php
@@ -23,7 +23,7 @@ class LockerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testLockThrowsExceptionIfUnableToCreateLockFile()
     {

--- a/tests/Patch/Task/CheckModuleCmsDependencyHandlerTest.php
+++ b/tests/Patch/Task/CheckModuleCmsDependencyHandlerTest.php
@@ -76,7 +76,7 @@ class CheckModuleCmsDependencyHandlerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException UnexpectedValueException
+     * @expectedException \UnexpectedValueException
      */
     public function testThrowsExceptionWhenVersionConstraintIsInvalid()
     {

--- a/tests/Patch/Task/TaskBusTest.php
+++ b/tests/Patch/Task/TaskBusTest.php
@@ -2,7 +2,6 @@
 
 namespace Meteor\Patch\Task;
 
-use InvalidArgumentException;
 use Mockery;
 
 class TaskBusTest extends \PHPUnit_Framework_TestCase
@@ -31,7 +30,7 @@ class TaskBusTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testThrowsExceptionWhenMissingHandler()
     {

--- a/tests/Patch/Version/VersionComparerTest.php
+++ b/tests/Patch/Version/VersionComparerTest.php
@@ -138,7 +138,7 @@ class VersionComparerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testCompareThrowsExceptionWhenUnableToFindVersionFileInWorkingDir()
     {

--- a/tests/Platform/Unix/InstallConfigLoaderTest.php
+++ b/tests/Platform/Unix/InstallConfigLoaderTest.php
@@ -15,7 +15,7 @@ class InstallConfigLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoad()
     {
-        $installConf = <<<CONF
+        $installConf = <<<'CONF'
 JADU_VERSION="1.12"
 VERBOSE=
 GNU="yes"
@@ -84,7 +84,7 @@ CONF;
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unable to open
      */
     public function testLoadThrowsExceptionWhenFileDoesNotExist()
@@ -95,7 +95,7 @@ CONF;
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unable to parse
      */
     public function testLoadThrowsExceptionWhenFileCannotBeParsed()

--- a/tests/Process/ProcessRunnerTest.php
+++ b/tests/Process/ProcessRunnerTest.php
@@ -3,7 +3,6 @@
 namespace Meteor\Process;
 
 use Meteor\IO\NullIO;
-use RuntimeException;
 
 class ProcessRunnerTest extends \PHPUnit_Framework_TestCase
 {
@@ -22,7 +21,7 @@ class ProcessRunnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testRunThrowsExceptionWithErrorOutputWhenNotSuccessful()
     {

--- a/tests/Scripts/ServiceContainer/ScriptsExtensionTest.php
+++ b/tests/Scripts/ServiceContainer/ScriptsExtensionTest.php
@@ -69,7 +69,7 @@ class ScriptsExtensionTest extends ExtensionTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Circular reference detected in "test" to "test"
      */
     public function testConfigPreventsInfiniteRecursion()
@@ -82,7 +82,7 @@ class ScriptsExtensionTest extends ExtensionTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Circular reference detected in "test2" to "test1"
      */
     public function testConfigPreventsInfiniteRecursionWithScriptReferences()
@@ -96,7 +96,7 @@ class ScriptsExtensionTest extends ExtensionTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Circular reference detected in "test5" to "test1"
      */
     public function testConfigPreventsInfiniteRecursionWithDeepScriptReferences()
@@ -113,7 +113,7 @@ class ScriptsExtensionTest extends ExtensionTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function testConfigCannotContainMultiDimentionalScripts()
     {

--- a/tests/ServiceContainer/ExtensionManagerTest.php
+++ b/tests/ServiceContainer/ExtensionManagerTest.php
@@ -45,7 +45,7 @@ class ExtensionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\ServiceContainer\Exception\ExtensionInitializationException
+     * @expectedException \Meteor\ServiceContainer\Exception\ExtensionInitializationException
      */
     public function testActivateExtensionThrowsExceptionWhenClassNotFound()
     {
@@ -53,7 +53,7 @@ class ExtensionManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Meteor\ServiceContainer\Exception\ExtensionInitializationException
+     * @expectedException \Meteor\ServiceContainer\Exception\ExtensionInitializationException
      */
     public function testActivateExtensionThrowsExceptionWhenNotImplementingExceptionInterface()
     {

--- a/tests/ServiceContainer/ExtensionTestCase.php
+++ b/tests/ServiceContainer/ExtensionTestCase.php
@@ -2,6 +2,8 @@
 
 namespace Meteor\ServiceContainer;
 
+use Composer\Autoload\ClassLoader;
+use Meteor\Autoload\ServiceContainer\AutoloadExtension;
 use Meteor\Cli\Application;
 use Meteor\Cli\ServiceContainer\CliExtension;
 use Meteor\Configuration\ConfigurationLoader;
@@ -30,6 +32,7 @@ abstract class ExtensionTestCase extends \PHPUnit_Framework_TestCase
     protected $configurationLoader;
     protected $extensionManager;
     protected $containerLoader;
+    protected $classLoader;
     protected $input;
     protected $output;
 
@@ -43,17 +46,20 @@ abstract class ExtensionTestCase extends \PHPUnit_Framework_TestCase
             $this->extensionManager
         );
 
+        $this->classLoader = new ClassLoader();
         $this->input = new ArrayInput([]);
         $this->output = new NullOutput();
     }
 
-    protected function loadContainer(array $config)
+    protected function loadContainer(array $config, $workingDir = null)
     {
         $container = new ContainerBuilder();
 
+        $container->set(AutoloadExtension::SERVICE_CLASS_LOADER, $this->classLoader);
         $container->set(CliExtension::SERVICE_INPUT, $this->input);
         $container->set(CliExtension::SERVICE_OUTPUT, $this->output);
         $container->set(ConfigurationExtension::SERVICE_LOADER, $this->configurationLoader);
+        $container->setParameter(Application::PARAMETER_WORKING_DIR, $workingDir);
 
         $config = $this->containerLoader->load($container, $config, null);
         $container->setParameter(Application::PARAMETER_CONFIG, $config);
@@ -73,6 +79,7 @@ abstract class ExtensionTestCase extends \PHPUnit_Framework_TestCase
     public function createExtensions()
     {
         return [
+            new AutoloadExtension(),
             new CliExtension(),
             new ConfigurationExtension(),
             new EventDispatcherExtension(),


### PR DESCRIPTION
Fixes #52 

Supports adding paths from Composer packages or explicitly with PSR-4 autoload paths.

```
"autoload": {
    "composer": ["spacecraft/migrations"],
    "psr-4": {
        "Jadu\\": "jadu/"
    }
}
```