### PR TITLE
Allows the manifest file to be missing.

### DIFF
--- a/src/Patch/Manifest/ManifestChecker.php
+++ b/src/Patch/Manifest/ManifestChecker.php
@@ -29,7 +29,7 @@ class ManifestChecker
         $manifestFile = $workingDir . '/' . self::MANIFEST_FILENAME;
         if (!file_exists($manifestFile)) {
             // The manifest did not exist
-            return false;
+            return true;
         }
 
         $manifest = json_decode(file_get_contents($manifestFile), true);

--- a/tests/Patch/Manifest/ManifestCheckerTest.php
+++ b/tests/Patch/Manifest/ManifestCheckerTest.php
@@ -20,9 +20,9 @@ class ManifestCheckerTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function testReturnsFalseIfManifestFileDoesNotExist()
+    public function testReturnsTrueIfManifestFileDoesNotExist()
     {
-        $this->assertFalse($this->manifestChecker->check(vfsStream::url('root')));
+        $this->assertTrue($this->manifestChecker->check(vfsStream::url('root')));
     }
 
     public function testReturnsFalseIfManifestFileCouldNotBeParsed()


### PR DESCRIPTION
This is so that older packages that do not yet use `meteor package` will still work.