### PR TITLE
Permission reset after patch doesn't work in WISP environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 before_script:
   - wget http://getcomposer.org/composer.phar
   - php composer.phar install --no-interaction
-  - php composer.phar require satooshi/php-coveralls:dev-master
+  - php composer.phar require satooshi/php-coveralls
   - php composer.phar dump-autoload --optimize
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 before_script:
   - wget http://getcomposer.org/composer.phar
   - php composer.phar install --no-interaction
-  - php composer.phar require satooshi/php-coveralls
+  - php composer.phar require php-coveralls/php-coveralls
   - php composer.phar dump-autoload --optimize
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Adds correction to permission reset command in Troubleshooting documentation ([#94](https://github.com/jadu/meteor/pull/94)).
+
 ## v3.1.0
 
 * Move migration step before set permissions step ([#75](https://github.com/jadu/meteor/pull/75)).

--- a/docs/_docs/troubleshooting.md
+++ b/docs/_docs/troubleshooting.md
@@ -63,7 +63,7 @@ php meteor.phar patch:clear-lock
 php meteor.phar patch:apply --skip-backup
 ```
 
-If it has progressed passed this, and has copied the files from the package as well then again you will need to again clear the lock file; but this time you will need to specifically perform migrations, file migrations, setting of permissions, and any standard post-patch actions you may take such as clearing and/or warming of cache.
+If it has progressed passed this, and has copied the files from the package as well then again you will need to clear the lock file; but this time you will need to specifically perform migrations, file migrations, setting of permissions, and any standard post-patch actions you may take such as clearing and/or warming of cache.
 
 ```
 php meteor.phar patch:clear-lock

--- a/docs/_docs/troubleshooting.md
+++ b/docs/_docs/troubleshooting.md
@@ -72,4 +72,4 @@ php meteor.phar file-migrations:migrate
 php meteor.phar permissions:reset
 ```
 
-*Note:* If the file copying and/or back-up was slow enough for the database connection to time-out, then the `set-permissions` command will also take a similar amount of time to complete.
+*Note:* If the file copying and/or back-up was slow enough for the database connection to time-out, then the `permissions:reset` command will also take a similar amount of time to complete.

--- a/docs/_docs/troubleshooting.md
+++ b/docs/_docs/troubleshooting.md
@@ -69,7 +69,7 @@ If it has progressed passed this, and has copied the files from the package as w
 php meteor.phar patch:clear-lock
 php meteor.phar migrations:migrate
 php meteor.phar file-migrations:migrate
-php meteor.phar patch:set-permissions
+php meteor.phar permissions:reset
 ```
 
 *Note:* If the file copying and/or back-up was slow enough for the database connection to time-out, then the `set-permissions` command will also take a similar amount of time to complete.

--- a/docs/_docs/troubleshooting.md
+++ b/docs/_docs/troubleshooting.md
@@ -40,3 +40,21 @@ Running database migrations
 ```
 
 This warning means that some migrations that were previously executed do not exist within the package. This may be because they were deleted or potentially renamed. If these are core migrations (`jadu/cms` or `jadu/xfp`) then check with Support as this should not happen. To avoid this happening do not rename migration verisons after a patch has been applied. If you need to remove a migration then simply empty the `up` and `down` methods.
+
+### Database connection error
+
+If the first stages of deployment take a long time (e.g. due to network latency) then it is possible that the database
+connection may timeout before the migrations are applied. In this case you may see and error such as:
+
+```
+Error: PDOException
+SQLSTATE[HY000]: General error: 2006 MySQL server has gone away
+```
+
+To progress from this error, you will need to first clear the lock file and then re-apply the package, skipping the
+backup step, which should have completed successfully in the previous run:
+
+```
+php meteor.phar patch:clear-lock
+php meteor.phar patch:apply --skip-backup
+```

--- a/src/Process/ProcessRunner.php
+++ b/src/Process/ProcessRunner.php
@@ -36,7 +36,10 @@ class ProcessRunner
     public function run($command, $cwd = null, $callback = null, $timeout = self::DEFAULT_TIMEOUT)
     {
         $process = new Process($command);
-        $process->setWorkingDirectory($cwd);
+        if ($cwd) {
+            $process->setWorkingDirectory($cwd);
+        }
+
         $process->setTimeout($timeout);
 
         $this->io->debug(sprintf('Running command "%s" in "%s"', $command, $cwd !== null ? $cwd : getcwd()));


### PR DESCRIPTION
When patching WISP environments, the following warning is displayed:

```
 [WARNING] Unable to set permissions correctly for some files. They should be  
           set manually or by running `meteor permissions:reset` with the      
           correct permission.  
```

This happens because the following exception is thrown when the  permissions reset command is executed for each entry: The provided cwd does not exist 

This happens because the WindowsPlatform class tries to run a process without specifying the working directory and the process runner doesn’t do a check if the working directory is valid before setting it.

A check on ProcessRunner to see if the passed working dir is valid before setting it on the Process should fix the above