### PR TITLE
Add the patch apply command to delete vendor before it patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Adds a option to clear vendor folder before the start of the patch. 
+
 * Adds correction to permission reset command in Troubleshooting documentation ([#94](https://github.com/jadu/meteor/pull/94)).
 
 ## v3.1.0

--- a/box.json.dist
+++ b/box.json.dist
@@ -6,7 +6,6 @@
         "Herrera\\Box\\Compactor\\Php"
     ],
     "directories": ["src"],
-    "extract": true,
     "files": [],
     "finder": [
         {

--- a/docs/_docs/patch.md
+++ b/docs/_docs/patch.md
@@ -81,3 +81,23 @@ php meteor.phar patch:verify
 **patch (optional)**
 
 Defaults to: `overwrite`
+
+## Delete `vendor` before patching
+
+If at any time you want delete the vendor folder before the patch, the following command can be used:
+
+```
+php meteor.phar patch:apply --clear-vendor
+```
+
+You can use also use the meteor.json configuration to automate the clearing the vendor
+
+```json
+{
+    "extra": {
+        "clearVendor": true
+    }
+}
+```
+
+> By default, the vendor is not cleared during the patch. unless one of the above options is specified explicitly.

--- a/src/Configuration/ConfigurationLoader.php
+++ b/src/Configuration/ConfigurationLoader.php
@@ -56,6 +56,9 @@ class ConfigurationLoader
 
         $childrenNode->scalarNode('name')->defaultValue(uniqid('package'))->end();
         $childrenNode->arrayNode('extensions')->prototype('scalar')->end();
+        $extraChildrenNode = $childrenNode->arrayNode('extra')->children();
+        $extraChildrenNode->booleanNode('clearVendor')->defaultFalse()->end();
+        $extraChildrenNode->end();
 
         foreach ($extensions as $extension) {
             $extension->configure($childrenNode->arrayNode($extension->getConfigKey()));
@@ -66,6 +69,8 @@ class ConfigurationLoader
 
         $combinedChildrenNode->scalarNode('name')->defaultValue(uniqid('package'))->end();
         $combinedChildrenNode->arrayNode('extensions')->prototype('scalar')->end();
+
+
 
         // Build the combined section to allow all extension configs
         foreach ($extensions as $extension) {

--- a/src/Patch/Cli/Command/ApplyCommand.php
+++ b/src/Patch/Cli/Command/ApplyCommand.php
@@ -220,7 +220,7 @@ class ApplyCommand extends AbstractPatchCommand
         }
 
         $options = $this->io->getOptions();
-        $options['clear-vendor'] = $this->io->getOption('clear-vendor') || (isset($config['clear-vendor']) && boolval($config['clear-vendor']) === true );
+        $options['clear-vendor'] = $this->io->getOption('clear-vendor') || (isset($config['extra']['clearVendor']) && boolval($config['extra']['clearVendor']) === true );
 
         $tasks = $this->strategy->apply($workingDir, $installDir, $options);
         foreach ($tasks as $task) {

--- a/src/Patch/Cli/Command/ApplyCommand.php
+++ b/src/Patch/Cli/Command/ApplyCommand.php
@@ -111,6 +111,7 @@ class ApplyCommand extends AbstractPatchCommand
         $this->addOption('skip-lock', null, InputOption::VALUE_NONE, 'Skip any existing lock files to force a patch');
         $this->addOption('skip-scripts', null, InputOption::VALUE_NONE, 'Skip script execution');
         $this->addOption('ignore-unavailable-migrations', null, InputOption::VALUE_NONE, 'Ignore unavailable migrations.');
+        $this->addOption('clear-vendor', null, InputOption::VALUE_NONE, 'Clear vendor folder.');
 
         $this->strategy->configureApplyCommand($this->getDefinition());
 
@@ -218,7 +219,10 @@ class ApplyCommand extends AbstractPatchCommand
             $this->eventDispatcher->dispatch(PatchEvents::PRE_APPLY, new Event());
         }
 
-        $tasks = $this->strategy->apply($workingDir, $installDir, $this->io->getOptions());
+        $options = $this->io->getOptions();
+        $options['clear-vendor'] = $this->io->getOption('clear-vendor') || (isset($config['clear-vendor']) && boolval($config['clear-vendor']) === true );
+
+        $tasks = $this->strategy->apply($workingDir, $installDir, $options);
         foreach ($tasks as $task) {
             $result = $this->taskBus->run($task, $this->getConfiguration());
             if ($result === false) {

--- a/src/Patch/ServiceContainer/PatchExtension.php
+++ b/src/Patch/ServiceContainer/PatchExtension.php
@@ -48,6 +48,7 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
     const SERVICE_TASK_CHECK_WRITE_PERMISSION_HANDLER = 'patch.task.check_write_permission_handler';
     const SERVICE_TASK_COPY_FILES_HANDLER = 'patch.task.copy_files_handler';
     const SERVICE_TASK_DELETE_BACKUP_HANDLER = 'patch.task.delete_backup_handler';
+    const SERVICE_TASK_DELETE_VENDOR_FOLDER = 'patch.task.delete_vendor_folder';
     const SERVICE_TASK_DISPLAY_VERSION_INFO_HANDLER = 'patch.task.display_version_info_handler';
     const SERVICE_TASK_MIGRATE_DOWN_HANDLER = 'patch.task.migrate_down_handler';
     const SERVICE_TASK_MIGRATE_UP_HANDLER = 'patch.task.migrate_up_handler';
@@ -120,6 +121,7 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
         $this->loadCheckWritePermissionTaskHandler($container);
         $this->loadCopyFilesHandler($container);
         $this->loadDeleteBackupHandler($container);
+        $this->loadDeleteVendorHandler($container);
         $this->loadDisplayVersionInfoTaskHandler($container);
         $this->loadMigrateDownTaskHandler($container);
         $this->loadMigrateUpTaskHandler($container);
@@ -279,6 +281,22 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
         ]);
 
         $container->setDefinition(self::SERVICE_TASK_DELETE_BACKUP_HANDLER, $definition);
+    }
+
+    /**
+     * @param ContailerBuilder $container
+     */
+    private function loadDeleteVendorHandler(ContainerBuilder $container)
+    {
+        $definition = new Definition('Meteor\Patch\Task\DeleteVendorHandler', [
+            new Reference(IOExtension::SERVICE_IO),
+            new Reference(FilesystemExtension::SERVICE_FILESYSTEM),
+        ]);
+        $definition->addTag(self::TAG_TASK_HANDLER, [
+            'task' => 'Meteor\Patch\Task\DeleteVendor',
+        ]);
+
+        $container->setDefinition(self::SERVICE_TASK_DELETE_VENDOR_FOLDER, $definition);
     }
 
     /**

--- a/src/Patch/Strategy/Overwrite/OverwritePatchStrategy.php
+++ b/src/Patch/Strategy/Overwrite/OverwritePatchStrategy.php
@@ -13,6 +13,7 @@ use Meteor\Patch\Task\CheckVersion;
 use Meteor\Patch\Task\CheckWritePermission;
 use Meteor\Patch\Task\CopyFiles;
 use Meteor\Patch\Task\DeleteBackup;
+use Meteor\Patch\Task\DeleteVendor;
 use Meteor\Patch\Task\DisplayVersionInfo;
 use Meteor\Patch\Task\MigrateDown;
 use Meteor\Patch\Task\MigrateUp;
@@ -49,6 +50,10 @@ class OverwritePatchStrategy implements PatchStrategyInterface
         if (!$options['skip-backup']) {
             $tasks[] = new BackupFiles($backupDir, $patchDir, $installDir);
             $tasks[] = new UpdateMigrationVersionFiles($backupDir, $patchDir, $installDir);
+        }
+
+        if (isset($options['clear-vendor']) && $options['clear-vendor']) {
+            $tasks[] = new DeleteVendor($installDir);
         }
 
         $tasks[] = new CopyFiles($patchFilesDir, $installDir);
@@ -94,7 +99,6 @@ class OverwritePatchStrategy implements PatchStrategyInterface
         if (!$options['skip-db-migrations'] || !$options['skip-file-migrations']) {
             $tasks[] = new CheckDatabaseConnection($installDir);
         }
-
         $tasks[] = new CopyFiles($backupFilesDir, $installDir);
 
         if (!$options['skip-db-migrations']) {

--- a/src/Patch/Task/DeleteVendor.php
+++ b/src/Patch/Task/DeleteVendor.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Meteor\Patch\Task;
+
+class DeleteVendor
+{
+    /**
+     * @var string
+     */
+    public $installDir;
+
+    /**
+     * @param string $installDir
+     */
+    public function __construct($installDir)
+    {
+        $this->installDir = $installDir;
+    }
+
+    public function getVendorFolder()
+    {
+        return $this->installDir . '/vendor';
+    }
+}

--- a/src/Patch/Task/DeleteVendor.php
+++ b/src/Patch/Task/DeleteVendor.php
@@ -19,6 +19,6 @@ class DeleteVendor
 
     public function getVendorFolder()
     {
-        return $this->installDir . '/vendor';
+        return $this->installDir . DIRECTORY_SEPARATOR .  'vendor';
     }
 }

--- a/src/Patch/Task/DeleteVendorHandler.php
+++ b/src/Patch/Task/DeleteVendorHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Meteor\Patch\Task;
+
+use Meteor\Filesystem\Filesystem;
+use Meteor\IO\IOInterface;
+
+class DeleteVendorHandler
+{
+    /**
+     * @var IOInterface
+     */
+    private $io;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @param IOInterface $io
+     * @param Filesystem $filesystem
+     */
+    public function __construct(IOInterface $io, Filesystem $filesystem)
+    {
+        $this->io = $io;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * @param DeleteBackup $task
+     */
+    public function handle(DeleteVendor $task)
+    {
+        $this->io->text(sprintf('Removing the vendor <info>%s</>', $task->getVendorFolder()));
+        $this->filesystem->remove($task->getVendorFolder());
+    }
+}

--- a/tests/Patch/Task/DeleteVendorHandlerTest.php
+++ b/tests/Patch/Task/DeleteVendorHandlerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Meteor\Patch\Task;
+
+use Meteor\IO\NullIO;
+use Mockery;
+
+class DeleteVendorHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    private $io;
+    private $filesystem;
+    private $handler;
+
+    public function setUp()
+    {
+        $this->io = new NullIO();
+        $this->filesystem = Mockery::mock('Meteor\Filesystem\Filesystem', [
+            'findNewFiles' => [],
+            'copyDirectory' => null,
+        ]);
+
+        $this->handler = new DeleteVendorHandler($this->io, $this->filesystem);
+    }
+
+    public function testDeletesBackup()
+    {
+        $this->filesystem->shouldReceive('remove')
+            ->with('/a/b/c/vendor')
+            ->once();
+
+        $this->handler->handle(new DeleteVendor('/a/b/c'));
+    }
+}


### PR DESCRIPTION
This feature will allow deleting the vendor folder as part of the patch:apply command. This can be invoked manually and automated using a parameter in meteor.json.

To clear vendor using a command-line argument include `--clear-vendor` in your patch:apply command. 

To make its automatic add the following into your meteor.json

`    "extra": {
        "clearVendor": true
    }`
