### PR TITLE
MET-93: Add support for 'replace_directories' configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Add support for 'swap_folder' configuration option, allowing certain folders to be marked for slightly different patch strategy whereby the existing folder is removed and replaced entirely by the folder from the package.
 * Adds correction to permission reset command in Troubleshooting documentation ([#94](https://github.com/jadu/meteor/pull/94)).
 
 ## v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Add support for 'swap_folder' configuration option, allowing certain folders to be marked for slightly different patch strategy whereby the existing folder is removed and replaced entirely by the folder from the package.
+* Add support for 'replace_directories' configuration option, allowing certain folders to be marked for slightly different patch strategy whereby the existing folder is removed and replaced entirely by the folder from the package.
 * Adds correction to permission reset command in Troubleshooting documentation ([#94](https://github.com/jadu/meteor/pull/94)).
 
 ## v3.1.0

--- a/docs/_docs/patch.md
+++ b/docs/_docs/patch.md
@@ -73,11 +73,22 @@ php meteor.phar patch:verify
 ```json
 {
     "patch": {
-        "strategy": "overwrite"
+        "strategy": "overwrite",
+        "replace_directories": [
+            '/vendor'
+        ]
     }
 }
 ```
 
-**patch (optional)**
+### strategy (optional)
 
-Defaults to: `overwrite`
+Defaults to: `overwrite` - files are copied from the package over the top of the same location in the install.
+
+### replace_directories (optional)
+
+List of directories that should be removed from the install before the version in the package is copied in. This is
+useful for directories like `/vendor`, where the contents may change significantly between releases and tracking of any
+files to be removed is beyond your control.
+
+Defaults to empty.

--- a/docs/_docs/patch.md
+++ b/docs/_docs/patch.md
@@ -75,7 +75,7 @@ php meteor.phar patch:verify
     "patch": {
         "strategy": "overwrite",
         "replace_directories": [
-            '/vendor'
+            "/vendor"
         ]
     }
 }

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -220,12 +220,16 @@ class Filesystem extends BaseFilesystem
      */
     public function replaceDirectory($sourceDir, $targetDir, $replaceDirectory)
     {
+        $this->io->text(sprintf('Replacing directory <info>%s</>', $targetDir . $replaceDirectory));
+
         $tempTarget = uniqid($replaceDirectory);
 
         $this->copyDirectory($sourceDir . $replaceDirectory, $targetDir . $tempTarget);
 
+        $this->io->debug(sprintf("Removing %s", $targetDir . $replaceDirectory));
         $this->removeDirectory($targetDir . $replaceDirectory);
 
+        $this->io->debug(sprintf("Renaming %s to %s", $targetDir . $tempTarget, $targetDir . $replaceDirectory));
         rename($targetDir . $tempTarget, $targetDir . $replaceDirectory);
     }
 }

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -208,24 +208,24 @@ class Filesystem extends BaseFilesystem
     }
 
     /**
-     * Copy $swapDirectory from $sourceDir to a temporary location, then remove $swapDirectory from $targetDir and
+     * Copy $replaceDirectory from $sourceDir to a temporary location, then remove $replaceDirectory from $targetDir and
      * replace it with the temporary copy. Used to quickly move a directory of items into place, completely removing
      * anything in the existing target location.
      *
-     * Example usage: swapDirectory('/package', '/install/home', '/vendor')
+     * Example usage: replaceDirectory('/package', '/install/home', '/vendor')
      *
      * @param string $sourceDir
      * @param string $targetDir
-     * @param string $swapDirectory
+     * @param string $replaceDirectory
      */
-    public function swapDirectory($sourceDir, $targetDir, $swapDirectory)
+    public function replaceDirectory($sourceDir, $targetDir, $replaceDirectory)
     {
-        $tempTarget = uniqid($swapDirectory);
+        $tempTarget = uniqid($replaceDirectory);
 
-        $this->copyDirectory($sourceDir . $swapDirectory, $targetDir . $tempTarget);
+        $this->copyDirectory($sourceDir . $replaceDirectory, $targetDir . $tempTarget);
 
-        $this->removeDirectory($targetDir . $swapDirectory);
+        $this->removeDirectory($targetDir . $replaceDirectory);
 
-        rename($targetDir . $tempTarget, $targetDir . $swapDirectory);
+        rename($targetDir . $tempTarget, $targetDir . $replaceDirectory);
     }
 }

--- a/src/Filesystem/Finder/FinderFactory.php
+++ b/src/Filesystem/Finder/FinderFactory.php
@@ -26,7 +26,7 @@ class FinderFactory
             $finder->depth($depth);
         }
 
-        if (!empty($filters)) {
+        if ($filters !== null) {
             $patterns = [];
             foreach ($filters as $filter) {
                 $patterns[] = $this->generatePattern($filter);

--- a/src/Filesystem/Finder/FinderFactory.php
+++ b/src/Filesystem/Finder/FinderFactory.php
@@ -48,6 +48,8 @@ class FinderFactory
                         }
 
                         $include = true;
+                    } elseif ($negate && !$file->isDir()) {
+                        $include = true;
                     }
                 }
 

--- a/src/Filesystem/Finder/FinderFactory.php
+++ b/src/Filesystem/Finder/FinderFactory.php
@@ -26,7 +26,7 @@ class FinderFactory
             $finder->depth($depth);
         }
 
-        if ($filters !== null) {
+        if (!empty($filters)) {
             $patterns = [];
             foreach ($filters as $filter) {
                 $patterns[] = $this->generatePattern($filter);
@@ -48,7 +48,7 @@ class FinderFactory
                         }
 
                         $include = true;
-                    } elseif ($negate && !$file->isDir()) {
+                    } elseif ($negate) {
                         $include = true;
                     }
                 }

--- a/src/Patch/ServiceContainer/PatchExtension.php
+++ b/src/Patch/ServiceContainer/PatchExtension.php
@@ -100,7 +100,7 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
                 ->scalarNode('includeHiddenFiles')
                     // NB: Unused config parameter but added for backwards compatibility with old Meteor configs
                 ->end()
-                ->arrayNode('swap_folders')
+                ->arrayNode('replace_directories')
                     ->normalizeKeys(false)
                     ->defaultValue([])
                     ->prototype('scalar')->end()

--- a/src/Patch/ServiceContainer/PatchExtension.php
+++ b/src/Patch/ServiceContainer/PatchExtension.php
@@ -100,6 +100,12 @@ class PatchExtension extends ExtensionBase implements ExtensionInterface, Script
                 ->scalarNode('includeHiddenFiles')
                     // NB: Unused config parameter but added for backwards compatibility with old Meteor configs
                 ->end()
+                ->arrayNode('swap_folders')
+                    ->normalizeKeys(false)
+                    ->defaultValue([])
+                    ->prototype('scalar')->end()
+                    ->end()
+                ->end()
             ->end()
         ->end();
     }

--- a/src/Patch/Task/BackupFilesHandler.php
+++ b/src/Patch/Task/BackupFilesHandler.php
@@ -46,10 +46,22 @@ class BackupFilesHandler
 
         $this->filesystem->ensureDirectoryExists($task->backupDir);
 
+        $swapFolders = $config['patch']['swap_folders'];
+
+        $excludeFilters = [];
+        foreach ($swapFolders as $swapFolder) {
+            $excludeFilters[] = '!' . $swapFolder;
+        }
+
         // Copy the files from the install that exist in the patch to the backup
         $this->io->text('Copying files from the install to the backup:');
-        $files = $this->filesystem->findFiles($task->patchDir . '/' . PackageConstants::PATCH_DIR);
+        $files = $this->filesystem->findFiles($task->patchDir . '/' . PackageConstants::PATCH_DIR, $excludeFilters);
         $this->filesystem->copyFiles($files, $task->installDir, $task->backupDir . '/' . PackageConstants::PATCH_DIR);
+
+        // Backup everything that is marked as a swap_folder
+        foreach ($swapFolders as $swapFolder) {
+            $this->filesystem->copyDirectory($task->installDir . $swapFolder, $task->backupDir . $swapFolder);
+        }
 
         // Copy the meteor.json into the backup
         $configPath = $this->configurationLoader->resolve($task->patchDir);

--- a/src/Patch/Task/BackupFilesHandler.php
+++ b/src/Patch/Task/BackupFilesHandler.php
@@ -46,11 +46,11 @@ class BackupFilesHandler
 
         $this->filesystem->ensureDirectoryExists($task->backupDir);
 
-        $swapFolders = $config['patch']['swap_folders'];
+        $replaceDirectories = $config['patch']['replace_directories'];
 
         $excludeFilters = [];
-        foreach ($swapFolders as $swapFolder) {
-            $excludeFilters[] = '!' . $swapFolder;
+        foreach ($replaceDirectories as $directory) {
+            $excludeFilters[] = '!' . $directory;
         }
 
         // Copy the files from the install that exist in the patch to the backup
@@ -58,10 +58,10 @@ class BackupFilesHandler
         $files = $this->filesystem->findFiles($task->patchDir . '/' . PackageConstants::PATCH_DIR, $excludeFilters);
         $this->filesystem->copyFiles($files, $task->installDir, $task->backupDir . '/' . PackageConstants::PATCH_DIR);
 
-        // Backup everything that is marked as a swap_folder
-        foreach ($swapFolders as $swapFolder) {
-            $this->io->debug(sprintf("Backing up %s to %s", $task->installDir . $swapFolder, $task->backupDir . '/' . PackageConstants::PATCH_DIR . $swapFolder));
-            $this->filesystem->copyDirectory($task->installDir . $swapFolder, $task->backupDir . '/' . PackageConstants::PATCH_DIR . $swapFolder);
+        // Backup everything that is marked as a replace directory
+        foreach ($replaceDirectories as $directory) {
+            $this->io->debug(sprintf("Backing up %s to %s", $task->installDir . $directory, $task->backupDir . '/' . PackageConstants::PATCH_DIR . $directory));
+            $this->filesystem->copyDirectory($task->installDir . $directory, $task->backupDir . '/' . PackageConstants::PATCH_DIR . $directory);
         }
 
         // Copy the meteor.json into the backup

--- a/src/Patch/Task/BackupFilesHandler.php
+++ b/src/Patch/Task/BackupFilesHandler.php
@@ -60,7 +60,8 @@ class BackupFilesHandler
 
         // Backup everything that is marked as a swap_folder
         foreach ($swapFolders as $swapFolder) {
-            $this->filesystem->copyDirectory($task->installDir . $swapFolder, $task->backupDir . $swapFolder);
+            $this->io->debug(sprintf("Backing up %s to %s", $task->installDir . $swapFolder, $task->backupDir . '/' . PackageConstants::PATCH_DIR . $swapFolder));
+            $this->filesystem->copyDirectory($task->installDir . $swapFolder, $task->backupDir . '/' . PackageConstants::PATCH_DIR . $swapFolder);
         }
 
         // Copy the meteor.json into the backup

--- a/src/Patch/Task/BackupFilesHandler.php
+++ b/src/Patch/Task/BackupFilesHandler.php
@@ -56,13 +56,16 @@ class BackupFilesHandler
         // Copy the files from the install that exist in the patch to the backup
         $this->io->text('Copying files from the install to the backup:');
         $files = $this->filesystem->findFiles($task->patchDir . '/' . PackageConstants::PATCH_DIR, $excludeFilters);
-        $this->filesystem->copyFiles($files, $task->installDir, $task->backupDir . '/' . PackageConstants::PATCH_DIR);
 
-        // Backup everything that is marked as a replace directory
+        // Backup everything in the install that is marked as a replace directory
         foreach ($replaceDirectories as $directory) {
-            $this->io->debug(sprintf("Backing up %s to %s", $task->installDir . $directory, $task->backupDir . '/' . PackageConstants::PATCH_DIR . $directory));
-            $this->filesystem->copyDirectory($task->installDir . $directory, $task->backupDir . '/' . PackageConstants::PATCH_DIR . $directory);
+            $this->io->debug(sprintf("Adding replace directory %s to backup files", $task->installDir . $directory));
+            $replaceFiles = $this->filesystem->findFiles($task->installDir . $directory);
+
+            $files = array_merge($files, $replaceFiles);
         }
+
+        $this->filesystem->copyFiles($files, $task->installDir, $task->backupDir . '/' . PackageConstants::PATCH_DIR);
 
         // Copy the meteor.json into the backup
         $configPath = $this->configurationLoader->resolve($task->patchDir);

--- a/src/Patch/Task/BackupFilesHandler.php
+++ b/src/Patch/Task/BackupFilesHandler.php
@@ -60,7 +60,7 @@ class BackupFilesHandler
         // Backup everything in the install that is marked as a replace directory
         foreach ($replaceDirectories as $directory) {
             $this->io->debug(sprintf("Adding replace directory %s to backup files", $task->installDir . $directory));
-            $replaceFiles = $this->filesystem->findFiles($task->installDir . $directory);
+            $replaceFiles = $this->filesystem->findFiles($task->installDir, [$directory]);
 
             $files = array_merge($files, $replaceFiles);
         }

--- a/src/Patch/Task/CopyFilesHandler.php
+++ b/src/Patch/Task/CopyFilesHandler.php
@@ -54,7 +54,6 @@ class CopyFilesHandler
         $this->filesystem->copyDirectory($task->sourceDir, $task->targetDir, $excludeFilters);
 
         foreach ($replaceDirectories as $directory) {
-            $this->io->debug(sprintf("Replacing directory %s in %s", $directory, $task->targetDir));
             $this->filesystem->replaceDirectory($task->sourceDir, $task->targetDir, $directory);
         }
 

--- a/src/Patch/Task/CopyFilesHandler.php
+++ b/src/Patch/Task/CopyFilesHandler.php
@@ -45,15 +45,16 @@ class CopyFilesHandler
 
         $swapFolders = $config['patch']['swap_folders'];
 
-        $findFilters = [];
+        $excludeFilters = [];
         foreach ($swapFolders as $swapFolder) {
-            $findFilters[] = '!' . $swapFolder;
+            $excludeFilters[] = '!' . $swapFolder;
         }
 
-        $newFiles = $this->filesystem->findNewFiles($task->sourceDir, $task->targetDir, $findFilters);
-        $this->filesystem->copyDirectory($task->sourceDir, $task->targetDir, $swapFolders);
+        $newFiles = $this->filesystem->findNewFiles($task->sourceDir, $task->targetDir, $excludeFilters);
+        $this->filesystem->copyDirectory($task->sourceDir, $task->targetDir, $excludeFilters);
 
         foreach ($swapFolders as $swapFolder) {
+            $this->io->debug(sprintf("Swapping %s into %s", $swapFolder, $task->targetDir));
             $this->filesystem->swapDirectory($task->sourceDir, $task->targetDir, $swapFolder);
         }
 

--- a/src/Patch/Task/CopyFilesHandler.php
+++ b/src/Patch/Task/CopyFilesHandler.php
@@ -43,19 +43,19 @@ class CopyFilesHandler
     {
         $this->io->text(sprintf('Copying files into the install <info>%s</>', $task->targetDir));
 
-        $swapFolders = $config['patch']['swap_folders'];
+        $replaceDirectories = $config['patch']['replace_directories'];
 
         $excludeFilters = [];
-        foreach ($swapFolders as $swapFolder) {
-            $excludeFilters[] = '!' . $swapFolder;
+        foreach ($replaceDirectories as $directory) {
+            $excludeFilters[] = '!' . $directory;
         }
 
         $newFiles = $this->filesystem->findNewFiles($task->sourceDir, $task->targetDir, $excludeFilters);
         $this->filesystem->copyDirectory($task->sourceDir, $task->targetDir, $excludeFilters);
 
-        foreach ($swapFolders as $swapFolder) {
-            $this->io->debug(sprintf("Swapping %s into %s", $swapFolder, $task->targetDir));
-            $this->filesystem->swapDirectory($task->sourceDir, $task->targetDir, $swapFolder);
+        foreach ($replaceDirectories as $directory) {
+            $this->io->debug(sprintf("Replacing directory %s in %s", $directory, $task->targetDir));
+            $this->filesystem->replaceDirectory($task->sourceDir, $task->targetDir, $directory);
         }
 
         $this->permissionSetter->setDefaultPermissions($newFiles, $task->targetDir);

--- a/src/Patch/Task/CopyFilesHandler.php
+++ b/src/Patch/Task/CopyFilesHandler.php
@@ -43,8 +43,20 @@ class CopyFilesHandler
     {
         $this->io->text(sprintf('Copying files into the install <info>%s</>', $task->targetDir));
 
-        $newFiles = $this->filesystem->findNewFiles($task->sourceDir, $task->targetDir);
-        $this->filesystem->copyDirectory($task->sourceDir, $task->targetDir);
+        $swapFolders = $config['patch']['swap_folders'];
+
+        $findFilters = [];
+        foreach ($swapFolders as $swapFolder) {
+            $findFilters[] = '!' . $swapFolder;
+        }
+
+        $newFiles = $this->filesystem->findNewFiles($task->sourceDir, $task->targetDir, $findFilters);
+        $this->filesystem->copyDirectory($task->sourceDir, $task->targetDir, $swapFolders);
+
+        foreach ($swapFolders as $swapFolder) {
+            $this->filesystem->swapDirectory($task->sourceDir, $task->targetDir, $swapFolder);
+        }
+
         $this->permissionSetter->setDefaultPermissions($newFiles, $task->targetDir);
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -196,6 +196,37 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         $this->filesystem->findFiles($sourceDir, ['/**']);
     }
 
+    public function testFindFilesWithFiltersRealFinderFactory()
+    {
+        vfsStream::setup('root', null, [
+            'public_html' => [
+                'index.html' => '',
+            ],
+            'var' => [
+                'config' => [
+                    'system.xml' => '',
+                ],
+                'file.cache' => ''
+            ],
+        ]);
+
+        $sourceDir = vfsStream::url('root');
+
+        $filters = ['!/var'];
+
+        $finder = new Finder();
+        $finder->in($sourceDir);
+
+        $filesystem = new Filesystem(new FinderFactory(), $this->io);
+
+        $files = $filesystem->findFiles($sourceDir, $filters);
+
+        $this->assertEquals([
+            'public_html',
+            'public_html/index.html',
+        ], $files);
+    }
+
     public function testFindNewFiles()
     {
         vfsStream::setup('root', null, [

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -343,7 +343,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
     }
 
 
-    public function testSwapDirectory()
+    public function testReplaceDirectory()
     {
         vfsStream::setup('root', null, [
             'source' => [
@@ -372,7 +372,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue(is_file(vfsStream::url('root/target/vendor/org/package/file_c.html')));
 
-        $this->filesystem->swapDirectory(vfsStream::url('root/source'), vfsStream::url('root/target'), '/vendor');
+        $this->filesystem->replaceDirectory(vfsStream::url('root/source'), vfsStream::url('root/target'), '/vendor');
 
         $this->assertTrue(is_file(vfsStream::url('root/target/vendor/org/package/file_a.html')));
         $this->assertFalse(is_file(vfsStream::url('root/target/vendor/org/package/file_c.html')));

--- a/tests/Filesystem/Finder/FinderFactoryTest.php
+++ b/tests/Filesystem/Finder/FinderFactoryTest.php
@@ -119,6 +119,7 @@ class FinderFactoryTest extends \PHPUnit_Framework_TestCase
                     '!/*VERSION',
                 ],
                 [
+                    'var',
                     'var/XFP_VERSION',
                 ],
             ],
@@ -196,6 +197,7 @@ class FinderFactoryTest extends \PHPUnit_Framework_TestCase
                     '!/vendor',
                 ],
                 [
+                    'public_html',
                     'public_html/.htaccess',
                 ],
             ],

--- a/tests/Filesystem/Finder/FinderFactoryTest.php
+++ b/tests/Filesystem/Finder/FinderFactoryTest.php
@@ -181,6 +181,24 @@ class FinderFactoryTest extends \PHPUnit_Framework_TestCase
                     'public_html/.htaccess',
                 ],
             ],
+            [
+                [
+                    'public_html' => [
+                        '.htaccess' => '',
+                    ],
+                    'vendor' => [
+                        'org' => [
+                            'package' => 'file.html'
+                        ]
+                    ]
+                ],
+                [
+                    '!/vendor',
+                ],
+                [
+                    'public_html/.htaccess',
+                ],
+            ],
         ];
     }
 }

--- a/tests/Patch/Task/BackupFilesHandlerTest.php
+++ b/tests/Patch/Task/BackupFilesHandlerTest.php
@@ -18,7 +18,7 @@ class BackupFilesHandlerTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->config['patch']['swap_folders'] = [];
+        $this->config['patch']['replace_directories'] = [];
         $this->filesystem = Mockery::mock(Filesystem::class, [
             'ensureDirectoryExists' => null,
             'findFiles' => [],
@@ -63,30 +63,25 @@ class BackupFilesHandlerTest extends PHPUnit_Framework_TestCase
         $this->handler->handle(new BackupFiles('install/backups/20160701000000', 'patch', 'install'), $this->config);
     }
 
-    public function testSwapFoldersAreExcludedFromNormalBackupCopy()
+    public function testReplaceDirectoriesAreExcludedFromNormalBackupCopy()
     {
         $config = [];
-        $config['patch']['swap_folders'] = [
+        $config['patch']['replace_directories'] = [
             '/vendor',
         ];
 
         $this->filesystem->shouldReceive('findFiles')
             ->with('patch/to_patch', ['!/vendor'])
-            ->andReturn([])
+            ->andReturn(['patch'])
             ->once();
 
-        $this->handler->handle(new BackupFiles('install/backups/20160701000000', 'patch', 'install'), $config);
-    }
+        $this->filesystem->shouldReceive('findFiles')
+            ->with('install/vendor')
+            ->andReturn(['vendor'])
+            ->once();
 
-    public function testSwapFoldersAreFullyBackedUp()
-    {
-        $config = [];
-        $config['patch']['swap_folders'] = [
-            '/vendor',
-        ];
-
-        $this->filesystem->shouldReceive('copyDirectory')
-            ->with('install/vendor', 'install/backups/20160701000000/to_patch/vendor')
+        $this->filesystem->shouldReceive('copyFiles')
+            ->with(['patch', 'vendor'], 'install', 'install/backups/20160701000000/to_patch')
             ->andReturn([])
             ->once();
 

--- a/tests/Patch/Task/BackupFilesHandlerTest.php
+++ b/tests/Patch/Task/BackupFilesHandlerTest.php
@@ -86,7 +86,7 @@ class BackupFilesHandlerTest extends PHPUnit_Framework_TestCase
         ];
 
         $this->filesystem->shouldReceive('copyDirectory')
-            ->with('install/vendor', 'install/backups/20160701000000/vendor')
+            ->with('install/vendor', 'install/backups/20160701000000/to_patch/vendor')
             ->andReturn([])
             ->once();
 

--- a/tests/Patch/Task/BackupFilesHandlerTest.php
+++ b/tests/Patch/Task/BackupFilesHandlerTest.php
@@ -76,7 +76,7 @@ class BackupFilesHandlerTest extends PHPUnit_Framework_TestCase
             ->once();
 
         $this->filesystem->shouldReceive('findFiles')
-            ->with('install/vendor')
+            ->with('install', ['/vendor'])
             ->andReturn(['vendor'])
             ->once();
 

--- a/tests/Patch/Task/CopyFilesHandlerTest.php
+++ b/tests/Patch/Task/CopyFilesHandlerTest.php
@@ -15,19 +15,19 @@ class CopyFilesHandlerTest extends PHPUnit_Framework_TestCase
     private $permissionSetter;
     private $handler;
     private $defaultConfig = [];
-    private $swapFoldersConfig = [];
+    private $replaceDirectoriesConfig = [];
 
     public function setUp()
     {
-        $this->defaultConfig['patch']['swap_folders'] = [];
-        $this->swapFoldersConfig['patch']['swap_folders'] = [
+        $this->defaultConfig['patch']['replace_directories'] = [];
+        $this->replaceDirectoriesConfig['patch']['replace_directories'] = [
             '/vendor',
         ];
         $this->io = new NullIO();
         $this->filesystem = Mockery::mock(Filesystem::class, [
             'findNewFiles' => [],
             'copyDirectory' => null,
-            'swapDirectory' => null,
+            'replaceDirectory' => null,
         ]);
         $this->permissionSetter = Mockery::mock(PermissionSetter::class, [
             'setDefaultPermissions' => null,
@@ -69,25 +69,25 @@ class CopyFilesHandlerTest extends PHPUnit_Framework_TestCase
             ->with('source', 'target', ['!/vendor'])
             ->once();
 
-        $this->handler->handle(new CopyFiles('source', 'target'), $this->swapFoldersConfig);
+        $this->handler->handle(new CopyFiles('source', 'target'), $this->replaceDirectoriesConfig);
     }
 
-    public function testExcludesSwapFoldersFromFindNewFiles()
+    public function testExcludesReplaceDirectoriesFromFindNewFiles()
     {
          $this->filesystem->shouldReceive('findNewFiles')
             ->with('source', 'target', ['!/vendor'])
             ->andReturn([])
             ->once();
 
-        $this->handler->handle(new CopyFiles('source', 'target'), $this->swapFoldersConfig);
+        $this->handler->handle(new CopyFiles('source', 'target'), $this->replaceDirectoriesConfig);
     }
 
-    public function testProcessesSwapFolders()
+    public function testProcessesReplaceDirectories()
     {
-        $this->filesystem->shouldReceive('swapDirectory')
+        $this->filesystem->shouldReceive('replaceDirectory')
             ->with('source', 'target', '/vendor')
             ->once();
 
-        $this->handler->handle(new CopyFiles('source', 'target'), $this->swapFoldersConfig);
+        $this->handler->handle(new CopyFiles('source', 'target'), $this->replaceDirectoriesConfig);
     }
 }


### PR DESCRIPTION
Enables a different copying method to be used for listed folders (e.g. vendor) to prevent leftovers from previous versions causing issues.