### PR TITLE
MET-102 Fixes issue where combined package patch config was ignored

### DIFF
--- a/src/Patch/Task/BackupFilesHandler.php
+++ b/src/Patch/Task/BackupFilesHandler.php
@@ -48,6 +48,19 @@ class BackupFilesHandler
 
         $replaceDirectories = $config['patch']['replace_directories'];
 
+        if (isset($config['combined'])) {
+            foreach ($config['combined'] as $package) {
+                if (!isset($package['patch'])) {
+                    continue;
+                }
+
+                $replaceDirectories = array_merge(
+                    $replaceDirectories,
+                    $package['patch']['replace_directories']
+                );
+            }
+        }
+
         $excludeFilters = [];
 
         if (!empty($replaceDirectories)) {

--- a/src/Patch/Task/CopyFilesHandler.php
+++ b/src/Patch/Task/CopyFilesHandler.php
@@ -45,6 +45,19 @@ class CopyFilesHandler
 
         $replaceDirectories = $config['patch']['replace_directories'];
 
+        if (isset($config['combined'])) {
+            foreach ($config['combined'] as $package) {
+               if (!isset($package['patch'])) {
+                   continue;
+               }
+
+                $replaceDirectories = array_merge(
+                    $replaceDirectories,
+                    $package['patch']['replace_directories']
+                );
+            }
+        }
+
         $excludeFilters = [];
 
         if (!empty($replaceDirectories)) {

--- a/tests/Patch/Task/CopyFilesHandlerTest.php
+++ b/tests/Patch/Task/CopyFilesHandlerTest.php
@@ -90,4 +90,29 @@ class CopyFilesHandlerTest extends PHPUnit_Framework_TestCase
 
         $this->handler->handle(new CopyFiles('source', 'target'), $this->replaceDirectoriesConfig);
     }
+
+    public function testProcesseReplaceDirectoriesForCombinedPackages()
+    {
+        $config = [
+            'patch' => [
+                'replace_directories' => ['/vendor']
+            ],
+            'combined' => [
+                [
+                    'patch' => [
+                        'replace_directories' => ['/foo']
+                    ]
+                ]
+            ]
+        ];
+
+        $this->filesystem->shouldReceive('replaceDirectory')
+            ->with('source', 'target', '/foo')
+            ->once();
+        $this->filesystem->shouldReceive('replaceDirectory')
+            ->with('source', 'target', '/vendor')
+            ->once();
+
+        $this->handler->handle(new CopyFiles('source', 'target'), $config);
+    }
 }


### PR DESCRIPTION
Meteor will now check the patch->replace_directories config for each
combined package and merge it with the root package patch config.