### PR TITLE
Handling non existing upgrade/migrations/filesystem directory

### DIFF
--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -71,6 +71,11 @@ class Migrator
      */
     public function migrate($patchDir, $installDir, array $config, $type, $version, $ignoreUnavailableMigrations)
     {
+        if (!$this->validateConfiguration($type, $config, $patchDir)) {
+            $this->io->note(sprintf('No %s migrations to execute', $type));
+
+            return true;
+        }
         $configuration = $this->configurationFactory->createConfiguration($type, $config, $patchDir, $installDir);
         $executedMigrations = $configuration->getMigratedVersions();
         $availableMigrations = $configuration->getAvailableVersions();

--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -46,11 +46,13 @@ class Migrator
                 if (is_dir($patchDir . '/' . $config['directory'])) {
                     return true;
                 }
+
                 return false;
             case MigrationsConstants::TYPE_DATABASE:
                 if (is_dir($patchDir . '/' . $config['directory'])) {
                     return true;
                 }
+
                 return false;
             default:
                 return false;

--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -5,6 +5,7 @@ namespace Meteor\Migrations;
 use Doctrine\Migrations\Exception\MigrationException;
 use Meteor\IO\IOInterface;
 use Meteor\Migrations\Configuration\ConfigurationFactory;
+use Meteor\Migrations\Configuration\FileConfiguration;
 
 class Migrator
 {
@@ -28,6 +29,32 @@ class Migrator
     ) {
         $this->configurationFactory = $configurationFactory;
         $this->io = $io;
+    }
+
+    /**
+     * @param string $type
+     * @param array $config
+     * @param string $patchDir
+     *
+     * @return bool
+     */
+    public function validateConfiguration(string $type, array $config, string $patchDir): bool
+    {
+        switch ($type) {
+            case MigrationsConstants::TYPE_FILE:
+                $config['directory'] = $config['directory'] . '/' . FileConfiguration::MIGRATION_DIRECTORY;
+                if (is_dir($patchDir . '/' . $config['directory'])) {
+                    return true;
+                }
+                return false;
+            case MigrationsConstants::TYPE_DATABASE:
+                if (is_dir($patchDir . '/' . $config['directory'])) {
+                    return true;
+                }
+                return false;
+            default:
+                return false;
+        }
     }
 
     /**

--- a/src/Patch/Task/MigrateDownHandler.php
+++ b/src/Patch/Task/MigrateDownHandler.php
@@ -43,9 +43,11 @@ class MigrateDownHandler
     public function handle(MigrateDown $task, array $config)
     {
         if (isset($config['migrations'])) {
-            $result = $this->runMigrations($task->type, $task->backupDir, $task->workingDir, $task->installDir, $task->ignoreUnavailableMigrations, $config);
-            if (!$result) {
-                return false;
+            if ($this->migrator->validateConfiguration($task->type, $config['migrations'], $task->workingDir)) {
+                $result = $this->runMigrations($task->type, $task->backupDir, $task->workingDir, $task->installDir, $task->ignoreUnavailableMigrations, $config);
+                if (!$result) {
+                    return false;
+                }
             }
         }
 
@@ -54,9 +56,11 @@ class MigrateDownHandler
             $combinedConfigs = array_reverse($config['combined']);
             foreach ($combinedConfigs as $combinedConfig) {
                 if (isset($combinedConfig['migrations'])) {
-                    $result = $this->runMigrations($task->type, $task->backupDir, $task->workingDir, $task->installDir, $task->ignoreUnavailableMigrations, $combinedConfig);
-                    if (!$result) {
-                        return false;
+                    if ($this->migrator->validateConfiguration($task->type, $combinedConfig['migrations'], $task->workingDir)) {
+                        $result = $this->runMigrations($task->type, $task->backupDir, $task->workingDir, $task->installDir, $task->ignoreUnavailableMigrations, $combinedConfig);
+                        if (!$result) {
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/Patch/Task/MigrateUpHandler.php
+++ b/src/Patch/Task/MigrateUpHandler.php
@@ -36,18 +36,22 @@ class MigrateUpHandler
         if (isset($config['combined'])) {
             foreach ($config['combined'] as $combinedConfig) {
                 if (isset($combinedConfig['migrations'])) {
-                    $result = $this->runMigrations($task->type, $task->workingDir, $task->installDir, $task->ignoreUnavailableMigrations, $combinedConfig);
-                    if (!$result) {
-                        return false;
+                    if ($this->migrator->validateConfiguration($task->type, $combinedConfig['migrations'], $task->workingDir)) {
+                        $result = $this->runMigrations($task->type, $task->workingDir, $task->installDir, $task->ignoreUnavailableMigrations, $combinedConfig);
+                        if (!$result) {
+                            return false;
+                        }
                     }
                 }
             }
         }
 
         if (isset($config['migrations'])) {
-            $result = $this->runMigrations($task->type, $task->workingDir, $task->installDir, $task->ignoreUnavailableMigrations, $config);
-            if (!$result) {
-                return false;
+            if ($this->migrator->validateConfiguration($task->type, $config['migrations'], $task->workingDir)) {
+                $result = $this->runMigrations($task->type, $task->workingDir, $task->installDir, $task->ignoreUnavailableMigrations, $config);
+                if (!$result) {
+                    return false;
+                }
             }
         }
 

--- a/tests/Migrations/MigratorTest.php
+++ b/tests/Migrations/MigratorTest.php
@@ -34,7 +34,7 @@ class MigratorTest extends TestCase
 
     public function testMigrate()
     {
-        $config = [];
+        $config = ['directory' => 'upgrades'];
 
         $version1 = $this->createVersion('20160701000000');
         $version2 = $this->createVersion('20160702000000');
@@ -69,7 +69,7 @@ class MigratorTest extends TestCase
             });
 
         $this->configurationFactory->shouldReceive('createConfiguration')
-            ->with(MigrationsConstants::TYPE_DATABASE, $config, 'patch', 'install')
+            ->with(MigrationsConstants::TYPE_DATABASE, $config, __DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install')
             ->andReturn($configuration)
             ->once();
 
@@ -90,12 +90,18 @@ class MigratorTest extends TestCase
             ]))
             ->once();
 
-        static::assertTrue($this->migrator->migrate('patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, 'latest', false));
+        static::assertTrue($this->migrator->migrate(__DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, 'latest', false));
+    }
+
+    public function testMigrateReturnsTrueWhenNoFilesystemDirFound()
+    {
+        $config = ['directory' => 'upgrades'];
+        static::assertTrue($this->migrator->migrate(__DIR__ . '/Configuration/Fixtures/empty/patch', 'install', $config, MigrationsConstants::TYPE_FILE, 'latest', false));
     }
 
     public function testMigrateHaltsWhenUnavailableMigrationsFound()
     {
-        $config = [];
+        $config = ['directory' => 'upgrades'];
 
         $version1 = $this->createVersion('20160701000000');
         $version2 = $this->createVersion('20160702000000');
@@ -129,19 +135,19 @@ class MigratorTest extends TestCase
             });
 
         $this->configurationFactory->shouldReceive('createConfiguration')
-            ->with(MigrationsConstants::TYPE_DATABASE, $config, 'patch', 'install')
+            ->with(MigrationsConstants::TYPE_DATABASE, $config, __DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install')
             ->andReturn($configuration)
             ->once();
 
         $version1->shouldReceive('execute')
             ->never();
 
-        static::assertFalse($this->migrator->migrate('patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, 'latest', false));
+        static::assertFalse($this->migrator->migrate(__DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, 'latest', false));
     }
 
     public function testMigrateReturnsTrueWhenNoMigrationsToExecute()
     {
-        $config = [];
+        $config = ['directory' => 'upgrades'];
 
         $version1 = $this->createVersion('20160701000000');
         $version2 = $this->createVersion('20160702000000');
@@ -174,7 +180,7 @@ class MigratorTest extends TestCase
             });
 
         $this->configurationFactory->shouldReceive('createConfiguration')
-            ->with(MigrationsConstants::TYPE_DATABASE, $config, 'patch', 'install')
+            ->with(MigrationsConstants::TYPE_DATABASE, $config, __DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install')
             ->andReturn($configuration)
             ->once();
 
@@ -187,12 +193,12 @@ class MigratorTest extends TestCase
         $version3->shouldReceive('execute')
             ->never();
 
-        static::assertTrue($this->migrator->migrate('patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, 'latest', false));
+        static::assertTrue($this->migrator->migrate(__DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, 'latest', false));
     }
 
     public function testMigrateIgnoresUnavailableMigrations()
     {
-        $config = [];
+        $config = ['directory' => 'upgrades'];
 
         $version1 = $this->createVersion('20160701000000');
         $version2 = $this->createVersion('20160702000000');
@@ -225,7 +231,7 @@ class MigratorTest extends TestCase
             });
 
         $this->configurationFactory->shouldReceive('createConfiguration')
-            ->with(MigrationsConstants::TYPE_DATABASE, $config, 'patch', 'install')
+            ->with(MigrationsConstants::TYPE_DATABASE, $config, __DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install')
             ->andReturn($configuration)
             ->once();
 
@@ -239,7 +245,7 @@ class MigratorTest extends TestCase
             ]))
             ->once();
 
-        static::assertTrue($this->migrator->migrate('patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, 'latest', true));
+        static::assertTrue($this->migrator->migrate(__DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, 'latest', true));
     }
 
     public function testExecuteUp()
@@ -248,7 +254,7 @@ class MigratorTest extends TestCase
 
         $configuration = Mockery::mock(DatabaseConfiguration::class);
         $this->configurationFactory->shouldReceive('createConfiguration')
-            ->with(MigrationsConstants::TYPE_DATABASE, $config, 'patch', 'install')
+            ->with(MigrationsConstants::TYPE_DATABASE, $config, __DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install')
             ->andReturn($configuration)
             ->once();
 
@@ -265,7 +271,7 @@ class MigratorTest extends TestCase
             ]))
             ->once();
 
-        static::assertTrue($this->migrator->execute('patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, '20160701000000', 'up'));
+        static::assertTrue($this->migrator->execute(__DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, '20160701000000', 'up'));
     }
 
     public function testExecuteDown()
@@ -274,7 +280,7 @@ class MigratorTest extends TestCase
 
         $configuration = Mockery::mock(DatabaseConfiguration::class);
         $this->configurationFactory->shouldReceive('createConfiguration')
-            ->with(MigrationsConstants::TYPE_DATABASE, $config, 'patch', 'install')
+            ->with(MigrationsConstants::TYPE_DATABASE, $config, __DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install')
             ->andReturn($configuration)
             ->once();
 
@@ -288,6 +294,6 @@ class MigratorTest extends TestCase
             ->with('down')
             ->once();
 
-        static::assertTrue($this->migrator->execute('patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, '20160701000000', 'down'));
+        static::assertTrue($this->migrator->execute(__DIR__ . '/Configuration/Fixtures/with_migrations/patch', 'install', $config, MigrationsConstants::TYPE_DATABASE, '20160701000000', 'down'));
     }
 }

--- a/tests/Patch/Task/MigrateDownHandlerTest.php
+++ b/tests/Patch/Task/MigrateDownHandlerTest.php
@@ -42,6 +42,39 @@ class MigrateDownHandlerTest extends TestCase
             ->andReturn(true)
             ->once();
 
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->withAnyArgs()
+            ->andReturn(true)
+            ->once();
+
+        $task = new MigrateDown('backups/1', 'working', 'install', MigrationsConstants::TYPE_FILE, false);
+        $this->handler->handle($task, $config);
+    }
+
+    public function testNoFailureIfNoFilesystemDir()
+    {
+        $config = [
+            'name' => 'root',
+            'migrations' => [
+                'table' => 'Migrations',
+            ],
+        ];
+
+        $this->versionFileManager->shouldReceive('getCurrentVersion')
+            ->with('backups/1', 'Migrations', 'FILE_SYSTEM_MIGRATION_NUMBER')
+            ->andReturn('12345')
+            ->once();
+
+        $this->migrator->shouldReceive('migrate')
+            ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_FILE, '12345', false)
+            ->andReturn(true)
+            ->never();
+
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->withAnyArgs()
+            ->andReturn(false)
+            ->once();
+
         $task = new MigrateDown('backups/1', 'working', 'install', MigrationsConstants::TYPE_FILE, false);
         $this->handler->handle($task, $config);
     }
@@ -62,6 +95,10 @@ class MigrateDownHandlerTest extends TestCase
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_DATABASE, '12345', false)
+            ->andReturn(true)
+            ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->withAnyArgs()
             ->andReturn(true)
             ->once();
 
@@ -89,6 +126,10 @@ class MigrateDownHandlerTest extends TestCase
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][0]['migrations'], MigrationsConstants::TYPE_FILE, '12345', false)
+            ->andReturn(true)
+            ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->withAnyArgs()
             ->andReturn(true)
             ->once();
 
@@ -130,6 +171,10 @@ class MigrateDownHandlerTest extends TestCase
             ->andReturn(true)
             ->ordered()
             ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->withAnyArgs()
+            ->andReturn(true)
+            ->twice();
 
         $this->versionFileManager->shouldReceive('getCurrentVersion')
             ->with('backups/1', $config['combined'][1]['migrations']['table'], 'FILE_SYSTEM_MIGRATION_NUMBER')
@@ -187,6 +232,10 @@ class MigrateDownHandlerTest extends TestCase
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][0]['migrations'], MigrationsConstants::TYPE_FILE, '0', false)
             ->never();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->withAnyArgs()
+            ->andReturn(true)
+            ->once();
 
         $task = new MigrateDown('backups/1', 'working', 'install', MigrationsConstants::TYPE_FILE, false);
         $this->handler->handle($task, $config);
@@ -217,6 +266,10 @@ class MigrateDownHandlerTest extends TestCase
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][1]['migrations'], MigrationsConstants::TYPE_FILE, '0', false)
             ->andReturn(false)
+            ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->withAnyArgs()
+            ->andReturn(true)
             ->once();
 
         $this->migrator->shouldReceive('migrate')

--- a/tests/Patch/Task/MigrateUpHandlerTest.php
+++ b/tests/Patch/Task/MigrateUpHandlerTest.php
@@ -34,6 +34,32 @@ class MigrateUpHandlerTest extends TestCase
             ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_FILE, 'latest', false)
             ->andReturn(true)
             ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['migrations'], 'working')
+            ->andReturn(true)
+            ->once();
+
+        $task = new MigrateUp('working', 'install', MigrationsConstants::TYPE_FILE, false);
+        $this->handler->handle($task, $config);
+    }
+
+    public function testNoFailureIfNoFilesystemDir()
+    {
+        $config = [
+            'name' => 'root',
+            'migrations' => [
+                'table' => 'Migrations',
+            ],
+        ];
+
+        $this->migrator->shouldReceive('migrate')
+            ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_FILE, 'latest', false)
+            ->andReturn(true)
+            ->never();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['migrations'], 'working')
+            ->andReturn(false)
+            ->once();
 
         $task = new MigrateUp('working', 'install', MigrationsConstants::TYPE_FILE, false);
         $this->handler->handle($task, $config);
@@ -50,6 +76,10 @@ class MigrateUpHandlerTest extends TestCase
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_DATABASE, 'latest', false)
+            ->andReturn(true)
+            ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_DATABASE, $config['migrations'], 'working')
             ->andReturn(true)
             ->once();
 
@@ -72,6 +102,10 @@ class MigrateUpHandlerTest extends TestCase
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][0]['migrations'], MigrationsConstants::TYPE_FILE, 'latest', false)
+            ->andReturn(true)
+            ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['combined'][0]['migrations'], 'working')
             ->andReturn(true)
             ->once();
 
@@ -107,17 +141,29 @@ class MigrateUpHandlerTest extends TestCase
             ->andReturn(true)
             ->ordered()
             ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['combined'][0]['migrations'], 'working')
+            ->andReturn(true)
+            ->once();
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][1]['migrations'], MigrationsConstants::TYPE_FILE, 'latest', false)
             ->andReturn(true)
             ->ordered()
             ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['combined'][1]['migrations'], 'working')
+            ->andReturn(true)
+            ->once();
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_FILE, 'latest', false)
             ->andReturn(true)
             ->ordered()
+            ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['migrations'], 'working')
+            ->andReturn(true)
             ->once();
 
         $task = new MigrateUp('working', 'install', MigrationsConstants::TYPE_FILE, false);
@@ -145,10 +191,18 @@ class MigrateUpHandlerTest extends TestCase
             ->with('working', 'install', $config['migrations'], MigrationsConstants::TYPE_FILE, 'latest', false)
             ->andReturn(false)
             ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['migrations'], 'working')
+            ->andReturn(true)
+            ->once();
 
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][0]['migrations'], MigrationsConstants::TYPE_FILE, 'latest', false)
             ->never();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['combined'][0]['migrations'], 'working')
+            ->andReturn(true)
+            ->once();
 
         $task = new MigrateUp('working', 'install', MigrationsConstants::TYPE_FILE, false);
         $this->handler->handle($task, $config);
@@ -181,6 +235,14 @@ class MigrateUpHandlerTest extends TestCase
         $this->migrator->shouldReceive('migrate')
             ->with('working', 'install', $config['combined'][1]['migrations'], MigrationsConstants::TYPE_FILE, 'latest', false)
             ->never();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['combined'][0]['migrations'], 'working')
+            ->andReturn(true)
+            ->once();
+        $this->migrator->shouldReceive('validateConfiguration')
+            ->with(MigrationsConstants::TYPE_FILE, $config['combined'][1]['migrations'], 'working')
+            ->andReturn(true)
+            ->once();
 
         $task = new MigrateUp('working', 'install', MigrationsConstants::TYPE_FILE, false);
         $this->handler->handle($task, $config);


### PR DESCRIPTION
Validating the migrations directory exist before attempting to apply or rollback a patch.
If the directory does not exist no error is thrown and the command ends with success.